### PR TITLE
[Frame Time] Allow to terminate application after N frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Vulkan Performance Layers
 
-This project contains two Vulkan layers:
-1. Compile-time layer for measuring pipeline compilation times.
-2. Runtime layer for measuring pipeline execution times.
-3. Frame time layer for measuring time between calls to vkQueuePresentKHR, in nanoseconds.
+This project contains three Vulkan layers:
+1. Compile time layer for measuring pipeline compilation times. The output log file location can be set with the `VK_COMPILE_TIME_LOG` environment variable.
+2. *(Work in Progress)* Runtime layer for measuring pipeline execution times. The output log file location can be set with the `VK_RUNTIME_LOG` environment variable.
+3. Frame time layer for measuring time between calls to vkQueuePresentKHR, in nanoseconds. This layer can also terminate the parent Vulkan application after a given number of frames, controlled by the `VK_FRAME_TIME_EXIT_AFTER_FRAME` environment variable. The output log file location can be set with the `VK_FRAME_TIME_LOG` environment variable.
 
 The results are saved as CSV files.
 

--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -37,10 +37,11 @@ constexpr uint32_t kCompileTimeLayerVersion = 1;
 constexpr char kLayerName[] = "VK_LAYER_STADIA_pipeline_compile_time";
 constexpr char kLayerDescription[] =
     "Stadia Pipeline Compile Time Measuring Layer";
+constexpr char kLogFilenameEnvVar[] = "VK_COMPILE_TIME_LOG";
 
 performancelayers::LayerData* GetLayerData() {
   static performancelayers::LayerData* layer_data =
-      new performancelayers::LayerData(getenv("VK_COMPILE_TIME_LOG"),
+      new performancelayers::LayerData(getenv(kLogFilenameEnvVar),
                                        "Pipeline,Compile Time (ns)");
   return layer_data;
 }

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -36,10 +36,11 @@ constexpr uint32_t kRuntimeLayerVersion = 1;
 constexpr char kLayerName[] = "VK_LAYER_STADIA_pipeline_runtime";
 constexpr char kLayerDescription[] =
     "Stadia Pipeline Pipeline Runtime Measuring Layer";
+constexpr char kLogFilenameEnvVar[] = "VK_RUNTIME_LOG";
 
 performancelayers::RuntimeLayerData* GetLayerData() {
   static performancelayers::RuntimeLayerData* layer_data =
-      new performancelayers::RuntimeLayerData(getenv("VK_RUNTIME_LOG"));
+      new performancelayers::RuntimeLayerData(getenv(kLogFilenameEnvVar));
   return layer_data;
 }
 


### PR DESCRIPTION
This enables us to measure the performance of the fixed number of frames
without having to wait for a game to finish.

Also update the readme.