### PR TITLE
[Frame Time] Detect when benchmark exits

### DIFF
--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -40,10 +40,10 @@ constexpr char kLayerDescription[] =
 constexpr char kLogFilenameEnvVar[] = "VK_COMPILE_TIME_LOG";
 
 performancelayers::LayerData* GetLayerData() {
-  static performancelayers::LayerData* layer_data =
-      new performancelayers::LayerData(getenv(kLogFilenameEnvVar),
-                                       "Pipeline,Compile Time (ns)");
-  return layer_data;
+  // Don't use new -- make the destructor run when the layer gets unloaded.
+  static performancelayers::LayerData layer_data = performancelayers::LayerData(
+      getenv(kLogFilenameEnvVar), "Pipeline,Compile Time (ns)");
+  return &layer_data;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -78,6 +78,7 @@ LayerData::LayerData(char* log_filename, const char* header) {
     out_ = stderr;
   }
   fprintf(out_, "%s\n", header);
+  fflush(out_);
 }
 
 void LayerData::Log(const std::vector<uint64_t>& pipeline,
@@ -86,6 +87,7 @@ void LayerData::Log(const std::vector<uint64_t>& pipeline,
   // Quote the comma-separated hash value array to always create 2 CSV cells.
   fprintf(out_, "\"%s\",%" PRIu64 "\n", PipelineHashToString(pipeline).c_str(),
           time);
+  fflush(out_);
 }
 
 void LayerData::LogTimeDelta() {
@@ -94,6 +96,7 @@ void LayerData::LogTimeDelta() {
   if (last_log_time_ != absl::InfinitePast()) {
     const int64_t delta = ToInt64Nanoseconds(now - last_log_time_);
     fprintf(out_, "%" PRId64 "\n", delta);
+    fflush(out_);
   }
   last_log_time_ = now;
 }

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -39,9 +39,10 @@ constexpr char kLayerDescription[] =
 constexpr char kLogFilenameEnvVar[] = "VK_RUNTIME_LOG";
 
 performancelayers::RuntimeLayerData* GetLayerData() {
-  static performancelayers::RuntimeLayerData* layer_data =
-      new performancelayers::RuntimeLayerData(getenv(kLogFilenameEnvVar));
-  return layer_data;
+  // Don't use new -- make the destructor run when the layer gets unloaded.
+  static performancelayers::RuntimeLayerData layer_data =
+      performancelayers::RuntimeLayerData(getenv(kLogFilenameEnvVar));
+  return &layer_data;
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This will make sure that the finish indicator file is created when the
benchmarked Vulkan application exists on its own.

Make sure that layers' logs are flushed after each print to avoid
creating corrupted logs when benchmark dies.