### PR TITLE
Pass VkInstance to CreateDevice. Fixup intercepted function attributes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ target_include_directories(VkLayer_stadia_pipeline_compile_time PRIVATE
 )
 target_link_libraries(VkLayer_stadia_pipeline_compile_time PRIVATE
     absl::flat_hash_map
+    absl::flat_hash_set
     absl::strings
     absl::str_format
     absl::synchronization
@@ -85,6 +86,7 @@ target_include_directories(VkLayer_stadia_pipeline_runtime PRIVATE
 )
 target_link_libraries(VkLayer_stadia_pipeline_runtime PRIVATE
     absl::flat_hash_map
+    absl::flat_hash_set
     absl::strings
     absl::str_format
     absl::synchronization
@@ -107,6 +109,7 @@ target_include_directories(VkLayer_stadia_frame_time PRIVATE
 )
 target_link_libraries(VkLayer_stadia_frame_time PRIVATE
     absl::flat_hash_map
+    absl::flat_hash_set
     absl::strings
     absl::str_format
     absl::synchronization
@@ -141,6 +144,7 @@ target_include_directories(layer_support_tests PRIVATE
 )
 target_link_libraries(layer_support_tests PRIVATE
     absl::flat_hash_map
+    absl::flat_hash_set
     absl::strings
     absl::str_format
     absl::synchronization


### PR DESCRIPTION
CreateDevice needs to know the exact instance when there is more than
one layer active:
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap4.html#initialization-functionpointers.

Override EnumeratePhysicalDevices to keep a map from physical devices to
instances.