### PR TITLE
Handle GetDeviceProcAddr in GetInstanceProcAddr

### DIFF
--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -285,6 +285,7 @@ VK_LAYER_EXPORT VK_LAYER_PROC(PFN_vkVoidFunction)
   CHECK_FUNC(EnumerateDeviceLayerProperties);
   CHECK_FUNC(EnumerateInstanceLayerProperties);
   CHECK_FUNC(EnumeratePhysicalDevices);
+  CHECK_FUNC(GetDeviceProcAddr);
   CHECK_FUNC(GetInstanceProcAddr);
 #undef CHECK_FUNC
 

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -377,11 +377,12 @@ VK_LAYER_EXPORT VK_LAYER_PROC(PFN_vkVoidFunction)
   }
   CHECK_FUNC(CreateDevice);
   CHECK_FUNC(CreateInstance);
-  CHECK_FUNC(GetInstanceProcAddr);
   CHECK_FUNC(DestroyInstance);
   CHECK_FUNC(EnumerateDeviceLayerProperties);
   CHECK_FUNC(EnumerateInstanceLayerProperties);
   CHECK_FUNC(EnumeratePhysicalDevices);
+  CHECK_FUNC(GetDeviceProcAddr);
+  CHECK_FUNC(GetInstanceProcAddr);
 #undef CHECK_FUNC
 
   auto* layer_data = GetLayerData();

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -514,13 +514,14 @@ VK_LAYER_EXPORT VK_LAYER_PROC(PFN_vkVoidFunction)
   if (!strcmp(name, "vk" #func_name)) {                                     \
     return reinterpret_cast<PFN_vkVoidFunction>(&RuntimeLayer_##func_name); \
   }
-  CHECK_FUNC(GetInstanceProcAddr);
+  CHECK_FUNC(CreateDevice);
+  CHECK_FUNC(CreateInstance);
+  CHECK_FUNC(DestroyInstance);
+  CHECK_FUNC(EnumerateDeviceLayerProperties);
   CHECK_FUNC(EnumerateInstanceLayerProperties);
   CHECK_FUNC(EnumeratePhysicalDevices);
-  CHECK_FUNC(DestroyInstance);
-  CHECK_FUNC(CreateInstance);
-  CHECK_FUNC(CreateDevice);
-  CHECK_FUNC(EnumerateDeviceLayerProperties);
+  CHECK_FUNC(GetDeviceProcAddr);
+  CHECK_FUNC(GetInstanceProcAddr);
 #undef CHECK_FUNC
 
   performancelayers::RuntimeLayerData* layer_data = GetLayerData();


### PR DESCRIPTION
The spec implies have to support this case:
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap4.html#vkGetInstanceProcAddr.

This should resolve issues with running multiple layers at once.