### PR TITLE
Fix open source logging. Move logging implementation to a cc file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ message(STATUS "VulkanLoaderGenerated ${VulkanLoaderGenerated_INCLUDE_DIR}")
 add_library(performance_layers_support_lib INTERFACE)
 target_sources(performance_layers_support_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_data.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/log_scanner.cc
 )
 target_include_directories(performance_layers_support_lib INTERFACE
@@ -70,9 +71,6 @@ target_link_libraries(performance_layers_support_lib INTERFACE
     absl::str_format
     absl::synchronization
     farmhash
-)
-target_compile_definitions(performance_layers_support_lib INTERFACE
-	STADIA_PERFORMANCE_LAYERS_NO_GLOG=1
 )
 
 # Layer targets.

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@
 #include <string>
 
 #include "layer_data.h"
-#include "layer_utils.h"
 #include "log_scanner.h"
+#include "logging.h"
 
 #undef VK_LAYER_EXPORT
 #ifndef _WIN32
@@ -187,8 +187,9 @@ FrameTimeLayer_QueuePresentKHR(VkQueue queue,
   uint64_t exit_frame_num = layer_data->GetExitFrameNum();
   // If the layer should make Vulkan application exit after this frame.
   if (frames_elapsed == exit_frame_num) {
-    LOG(INFO) << "Stadia Frame Time Layer: Terminating application after frame "
-              << frames_elapsed << "\n";
+    SPL_LOG(INFO)
+        << "Stadia Frame Time Layer: Terminating application after frame "
+        << frames_elapsed;
 
     // _Exit will bring down the parent Vulkan application without running any
     // cleanup. Resources will be reclaimed by the operating system.

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/synchronization/mutex.h"
 #include "layer_utils.h"
+#include "logging.h"
 #include "vulkan/vulkan_core.h"
 
 namespace {
@@ -102,8 +103,8 @@ LayerData::LayerData(char* log_filename, const char* header) {
   if (log_filename) {
     out_ = fopen(log_filename, "w");
     if (out_ == nullptr) {
-      LOG(ERROR) << "Failed to open " << log_filename
-                 << ", output will be to STDERR.\n";
+      SPL_LOG(ERROR) << "Failed to open " << log_filename
+                     << ", output will be to STDERR.";
       out_ = stderr;
     }
   } else {

--- a/layer/layer_utils.h
+++ b/layer/layer_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,12 +14,5 @@
 
 #ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_
 #define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_
-
-#if defined(STADIA_PERFORMANCE_LAYERS_NO_GLOG)
-#include <iostream>
-#define LOG(KIND) std::cerr << "[" #KIND "]\t"
-#else
-#include "base/logging.h"
-#endif
 
 #endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_

--- a/layer/log_scanner.cc
+++ b/layer/log_scanner.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #include <cassert>
 
 #include "absl/strings/match.h"
-#include "layer_utils.h"
+#include "logging.h"
 
 namespace performancelayers {
 
@@ -26,7 +26,7 @@ std::optional<LogScanner> LogScanner::FromFilename(
     const std::string& filename) {
   std::ifstream file(filename);
   if (!file.good()) {
-    LOG(ERROR) << "Failed to open " << filename << "\n";
+    SPL_LOG(ERROR) << "Failed to open " << filename;
     return std::nullopt;
   }
 

--- a/layer/logging.cc
+++ b/layer/logging.cc
@@ -1,0 +1,54 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "logging.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string_view>
+
+namespace performancelayers {
+
+static const char* GetBasename(const char* filename) {
+  std::string_view path = filename;
+  if (size_t last_slash_pos = path.find_last_of("/\\");
+      (last_slash_pos != std::string_view::npos) &&
+      (last_slash_pos + 1 < path.size())) {
+    return filename + last_slash_pos + 1;
+  }
+  return filename;
+}
+
+void MessageLogger::PrintMessage() {
+  const char* prefix = "";
+  switch (kind_) {
+    case LogMessageKind::INFO:
+      prefix = "INFO";
+      break;
+    case LogMessageKind::WARNING:
+      prefix = "WARNING";
+      break;
+    case LogMessageKind::ERROR:
+      prefix = "ERROR";
+      break;
+    default:
+      assert(false);
+  }
+
+  fprintf(stderr, "[%s %s:%zu] %s\n", prefix, GetBasename(file_), line_,
+          message_.str().c_str());
+  fflush(stderr);
+}
+
+}  // namespace performancelayers

--- a/layer/logging.h
+++ b/layer/logging.h
@@ -1,0 +1,61 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOGGING_H_
+#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOGGING_H_
+
+#include <sstream>
+
+namespace performancelayers {
+enum class LogMessageKind { INFO, WARNING, ERROR };
+
+// Helper class for printing log messages. Exposes a common logging macro,
+// SPL_LOG, independent of the underlying logging library. Sample use:
+//   SPL_LOG(WARNING) << "Cannot load file: " << my_file_path;
+//
+// Note that there is no need to add a newline character at the end -- this is
+// handled by the implementation.
+class MessageLogger {
+ public:
+  MessageLogger(LogMessageKind kind, const char* file, size_t line)
+      : kind_(kind), file_(file), line_(line) {}
+  ~MessageLogger() { PrintMessage(); }
+
+  MessageLogger(const MessageLogger&) = delete;
+  MessageLogger& operator=(const MessageLogger&) = delete;
+  MessageLogger(MessageLogger&&) = delete;
+  MessageLogger& operator=(MessageLogger&&) = delete;
+
+  template <typename Arg>
+  MessageLogger& operator<<(Arg&& arg) {
+    message_ << std::forward<Arg>(arg);
+    return *this;
+  }
+
+ private:
+  void PrintMessage();
+  LogMessageKind kind_;
+  const char* file_;
+  size_t line_;
+  std::ostringstream message_;
+};
+}  // namespace performancelayers
+
+// Macro for printing logs. There are 3 log message kinds available: INFO,
+// WARNING, and ERROR.
+#define SPL_LOG(LOG_LEVEL_)         \
+  performancelayers::MessageLogger( \
+      performancelayers::LogMessageKind::LOG_LEVEL_, __FILE__, __LINE__)
+
+#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOGGING_H_

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "runtime_layer_data.h"
-
 #include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <functional>
 #include <string>
+
+#include "runtime_layer_data.h"
 
 #undef VK_LAYER_EXPORT
 #ifndef _WIN32

--- a/layer/runtime_layer_data.cc
+++ b/layer/runtime_layer_data.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 #include <inttypes.h>
 
-#include "layer_utils.h"
+#include "logging.h"
 
 namespace performancelayers {
 
@@ -94,9 +94,9 @@ void RuntimeLayerData::LogAndRemoveQueryPools() {
     if (result != VK_SUCCESS && result != VK_NOT_READY) {
       // This query failed for some reason. Remove it from the list so we do
       // not keep checking it.  Write an error to stderr.
-      LOG(ERROR) << "Timestamp query failed for "
-                 << PipelineHashToString(GetPipelineHash(info->pipeline))
-                 << " with error " << result;
+      SPL_LOG(ERROR) << "Timestamp query failed for "
+                     << PipelineHashToString(GetPipelineHash(info->pipeline))
+                     << " with error " << result;
       discard_result = true;
     } else if (result_available &&
                (timestamp0 == kInvalidValue || timestamp1 == kInvalidValue ||
@@ -104,10 +104,10 @@ void RuntimeLayerData::LogAndRemoveQueryPools() {
                 (timestamp1 - timestamp0 > kUnreasonablyLongRuntime))) {
       // This query did not produce valid timestamps for some reason. Remove
       // it from the list so we do not keep checking it.
-      LOG(ERROR) << "Timestamp query failed for "
-                 << PipelineHashToString(GetPipelineHash(info->pipeline))
-                 << " producing invalid timestamps: t0=" << timestamp0
-                 << ", t1=" << timestamp1;
+      SPL_LOG(ERROR) << "Timestamp query failed for "
+                     << PipelineHashToString(GetPipelineHash(info->pipeline))
+                     << " producing invalid timestamps: t0=" << timestamp0
+                     << ", t1=" << timestamp1;
       discard_result = true;
     }
 


### PR DESCRIPTION
Fix open source logging. Move logging implementation to a cc file.

Introduce a simple helper class for logging. This makes sure that
the concrete logging library is hidden from layer files that can't
depend on implementation details.

Include source file names and line numbers in open source logs.

This depends on https://github.com/googlestadia/performance-layers/pull/30 and needs to be rebased before submitting.