### PR TITLE
Implement InputBuffer class for reading files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ message(STATUS "VulkanLoaderGenerated ${VulkanLoaderGenerated_INCLUDE_DIR}")
 # The library with the common code shared by all layers.
 add_library(performance_layers_support_lib INTERFACE)
 target_sources(performance_layers_support_lib INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/input_buffer.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_utils.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/logging.cc
@@ -68,6 +69,8 @@ target_include_directories(performance_layers_support_lib INTERFACE
 target_link_libraries(performance_layers_support_lib INTERFACE
     absl::flat_hash_map
     absl::flat_hash_set
+    absl::status
+    absl::statusor
     absl::strings
     absl::str_format
     absl::synchronization
@@ -106,6 +109,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/layer
 
 enable_testing()
 add_executable(layer_support_tests
+    units/input_buffer_tests.cc
     units/log_scanner_tests.cc
 )
 target_include_directories(layer_support_tests PRIVATE

--- a/layer/input_buffer.cc
+++ b/layer/input_buffer.cc
@@ -1,0 +1,214 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "input_buffer.h"
+
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "logging.h"
+
+#if defined(__unix__)
+#include <fcntl.h>
+#include <sys/io.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace performancelayers {
+
+namespace {
+// Cross-platfrom input buffer implementation that reads file contents using
+// fopen/fread/fclose.
+class FileInputBufferImpl : public InputBuffer::InputBufferImplBase {
+ public:
+  static absl::StatusOr<std::unique_ptr<InputBuffer::InputBufferImplBase>>
+  Create(const std::string& path) {
+    struct FileCloser {
+      void operator()(FILE* file) {
+        if (file) fclose(file);
+      }
+    };
+    std::unique_ptr<FILE, FileCloser> handle(fopen(path.c_str(), "rb"));
+    if (!handle) {
+      return absl::UnavailableError(
+          absl::StrCat("Failed to fopen file for read: ", path));
+    }
+
+    fseek(handle.get(), 0, SEEK_END);
+    const auto file_size = ftell(handle.get());
+    fseek(handle.get(), 0, SEEK_SET);
+    if (file_size < 0) {
+      return absl::UnavailableError(
+          absl::StrCat("Failed to read file size: ", path));
+    }
+
+    const auto buffer_size = static_cast<size_t>(file_size);
+    FileInputBufferImpl res;
+    res.buffer_.resize(buffer_size);
+    if (fread(res.buffer_.data(), 1, buffer_size, handle.get()) !=
+        buffer_size) {
+      return absl::UnavailableError(
+          absl::StrCat("Failed to read file buffer contents: ", path));
+    }
+
+    return std::make_unique<FileInputBufferImpl>(std::move(res));
+  }
+
+  absl::Span<const uint8_t> GetBuffer() const override { return buffer_; }
+  ~FileInputBufferImpl() override = default;
+
+ private:
+  std::vector<uint8_t> buffer_;
+};
+
+#if defined(__unix__)
+// Unix memory mapped input buffer implementation.
+class UnixMemMappedInputBufferImpl : public InputBuffer::InputBufferImplBase {
+ public:
+  static absl::StatusOr<std::unique_ptr<InputBuffer::InputBufferImplBase>>
+  Create(const std::string& path) {
+    UnixMemMappedInputBufferImpl res;
+    res.file_descriptor_ = open(path.c_str(), O_RDONLY);
+    if (res.file_descriptor_ == -1) {
+      return absl::UnavailableError(
+          absl::StrCat("Failed to open file for read: ", path));
+    }
+
+    struct stat s = {};
+    if (fstat(res.file_descriptor_, &s) != 0) {
+      return absl::UnavailableError(
+          absl::StrCat("Failed to stat file: ", path));
+    }
+    size_t size = s.st_size;
+    if (size == 0) {
+      // We cannot mmap empty files, but we can return an empty buffer without
+      // mmaping the underlying file.
+      return std::make_unique<UnixMemMappedInputBufferImpl>(std::move(res));
+    }
+
+    // This memory is read-only, but we do not use a const pointer, because
+    // munmap takes the memory to unmap through a void * pointer. No non-const
+    // pointers ever leave this class.
+    void* data = mmap(0, size, PROT_READ, MAP_PRIVATE, res.file_descriptor_, 0);
+    if (data == MAP_FAILED) {
+      return absl::UnavailableError(
+          absl::StrCat("Failed to mmap file: ", path));
+    }
+
+    res.buffer_start_ = reinterpret_cast<uint8_t*>(data);
+    res.buffer_size_ = size;
+    SPL_LOG(INFO) << "Mmapped file " << path << " sz: " << size;
+    return std::make_unique<UnixMemMappedInputBufferImpl>(std::move(res));
+  }
+
+  absl::Span<const uint8_t> GetBuffer() const override {
+    assert(file_descriptor_ != -1);
+    assert(buffer_start_ != MAP_FAILED);
+    assert(buffer_start_ || buffer_size_ == 0);
+    return absl::MakeConstSpan(buffer_start_, buffer_size_);
+  }
+
+  UnixMemMappedInputBufferImpl(UnixMemMappedInputBufferImpl&& other)
+      : file_descriptor_(other.file_descriptor_),
+        buffer_start_(other.buffer_start_),
+        buffer_size_(other.buffer_size_) {
+    other.file_descriptor_ = -1;
+    other.buffer_start_ = nullptr;
+    other.buffer_size_ = 0;
+  }
+
+  UnixMemMappedInputBufferImpl& operator=(
+      UnixMemMappedInputBufferImpl&& other) {
+    reset();
+    std::swap(file_descriptor_, other.file_descriptor_);
+    std::swap(buffer_start_, other.buffer_start_);
+    std::swap(buffer_size_, other.buffer_size_);
+    return *this;
+  }
+
+  UnixMemMappedInputBufferImpl(const UnixMemMappedInputBufferImpl&) = delete;
+  UnixMemMappedInputBufferImpl& operator=(const UnixMemMappedInputBufferImpl&) =
+      delete;
+
+  ~UnixMemMappedInputBufferImpl() override { reset(); }
+
+ private:
+  UnixMemMappedInputBufferImpl() = default;
+
+  void reset() {
+    if (buffer_start_) munmap(buffer_start_, buffer_size_);
+    if (file_descriptor_ != -1) close(file_descriptor_);
+
+    file_descriptor_ = -1;
+    buffer_start_ = nullptr;
+    buffer_size_ = 0;
+  }
+
+  int file_descriptor_ = -1;
+  // This pointer is passed to munmap and cannot be const. The API does not
+  // expose it directly, and no non-const pointers ever leave the class.
+  uint8_t* buffer_start_ = nullptr;
+  size_t buffer_size_ = 0;
+};
+#endif  // defined(__unix__)
+
+}  // namespace
+
+absl::StatusOr<InputBuffer> InputBuffer::Create(
+    const std::string& path,
+    InputBuffer::ImplementationKind requested_implementation) {
+  switch (requested_implementation) {
+    case ImplementationKind::kFileRead: {
+      auto file_input_buffer_or_err = FileInputBufferImpl::Create(path);
+      if (file_input_buffer_or_err.ok())
+        return InputBuffer(std::move(*file_input_buffer_or_err));
+
+      return file_input_buffer_or_err.status();
+    }
+    case ImplementationKind::kMemMapped: {
+#if defined(__unix__)
+      auto mmap_input_buffer_or_err =
+          UnixMemMappedInputBufferImpl::Create(path);
+      if (mmap_input_buffer_or_err.ok())
+        return InputBuffer(std::move(*mmap_input_buffer_or_err));
+
+      return mmap_input_buffer_or_err.status();
+#else   // defined(__unix__)
+      return absl::UnavailableError(
+          "kMemMapped InputBuffer is implemented for this platform");
+#endif  // defined(__unix__)
+    }
+    default:
+      assert(false && "Case not handled.");
+  }
+}
+
+absl::StatusOr<InputBuffer> InputBuffer::Create(const std::string& path) {
+#if defined(__unix__)
+  constexpr auto kPreferredPlatformImpl =
+      InputBuffer::ImplementationKind::kMemMapped;
+#else
+  constexpr auto kPreferredPlatformImpl =
+      InputBuffer::ImplementationKind::kFileRead;
+#endif  // defined(__unix__)
+
+  return Create(path, kPreferredPlatformImpl);
+}
+
+}  // namespace performancelayers

--- a/layer/input_buffer.h
+++ b/layer/input_buffer.h
@@ -1,0 +1,74 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_INPUT_BUFFER_H_
+#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_INPUT_BUFFER_H_
+
+#include <cassert>
+#include <memory>
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+
+namespace performancelayers {
+
+// Represents a memory buffer, created with a path to the (on-disk) resource
+// to open and read.
+// Moveable but not copyable.
+class InputBuffer {
+ public:
+  enum class ImplementationKind { kFileRead, kMemMapped };
+
+  // Creates an input buffer by accessing the |path| file using a default
+  // platform-preferred implementation.
+  static absl::StatusOr<InputBuffer> Create(const std::string& path);
+
+  // Creates an input buffer by accessing the |path| file using the speficied
+  // |requested_implementation|. Returns an |absl::UnavailableError| if the
+  // requested implementation is not supported for the current platform.
+  static absl::StatusOr<InputBuffer> Create(
+      const std::string& path, ImplementationKind requested_implementation);
+
+  InputBuffer(InputBuffer&&) = default;
+  InputBuffer& operator=(InputBuffer&&) = default;
+
+  InputBuffer() = delete;
+  InputBuffer(const InputBuffer&) = delete;
+  InputBuffer& operator=(const InputBuffer&) = delete;
+
+  absl::Span<const uint8_t> GetBuffer() const {
+    assert(concrete_impl_);
+    return concrete_impl_->GetBuffer();
+  }
+
+  size_t GetBufferSize() const { return GetBuffer().size(); }
+
+  class InputBufferImplBase {
+   public:
+    virtual ~InputBufferImplBase() = default;
+    virtual absl::Span<const uint8_t> GetBuffer() const = 0;
+  };
+
+ private:
+  InputBuffer(std::unique_ptr<InputBufferImplBase> impl)
+      : concrete_impl_(std::move(impl)) {
+    assert(concrete_impl_);
+  }
+  std::unique_ptr<InputBufferImplBase> concrete_impl_ = nullptr;
+};
+
+}  // namespace performancelayers
+
+#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_INPUT_BUFFER_H_

--- a/units/input_buffer_tests.cc
+++ b/units/input_buffer_tests.cc
@@ -1,0 +1,155 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstdio>
+#include <filesystem>
+#include <numeric>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "input_buffer.h"
+#include "logging.h"
+
+namespace {
+
+using namespace performancelayers;
+namespace fs = std::filesystem;
+
+namespace {
+// Helper struct to create temporary files and fill them with test data.
+struct TmpFile {
+  TmpFile(const char* filename) {
+    fs::path tmp_dir = fs::temp_directory_path();
+    path = tmp_dir / filename;
+    // If the file already exists, this will automatically truncate it.
+    file = fopen(path.c_str(), "wb");
+    assert(file);
+  }
+  ~TmpFile() {
+    if (file) fclose(file);
+  }
+
+  void AppendData(absl::Span<const uint8_t> data) {
+    assert(file);
+    if (data.empty()) return;
+
+    size_t bytes_written = fwrite(data.data(), 1, data.size(), file);
+    (void)bytes_written;
+    assert(bytes_written == data.size());
+    fflush(file);
+  }
+
+  fs::path path = "";
+  FILE* file = nullptr;
+};
+}  // namespace
+
+TEST(InputBuffer, Placeholder) { ASSERT_TRUE(true); }
+
+TEST(InputBuffer, FileReadNotFound) {
+  auto buffer_or_err =
+      InputBuffer::Create("/definitely/nothing/here/perofrmancelayers.bin",
+                          InputBuffer::ImplementationKind::kFileRead);
+  EXPECT_FALSE(buffer_or_err.ok());
+  SPL_LOG(INFO) << buffer_or_err.status();
+}
+
+TEST(InputBuffer, FileReadEmptyFile) {
+  TmpFile tmp("cache.bin");
+  auto buffer_or_err = InputBuffer::Create(
+      tmp.path.c_str(), InputBuffer::ImplementationKind::kFileRead);
+  ASSERT_TRUE(buffer_or_err.ok());
+  EXPECT_EQ(buffer_or_err->GetBufferSize(), 0);
+  EXPECT_EQ(buffer_or_err->GetBuffer().size(), 0);
+
+  // Add some data to the underlying file. Since InputBuffer doesn't re-scan
+  // file contents, it should still report an empty buffer.
+  tmp.AppendData(std::vector<uint8_t>(42));
+  ASSERT_TRUE(buffer_or_err.ok());
+  EXPECT_EQ(buffer_or_err->GetBufferSize(), 0);
+  EXPECT_EQ(buffer_or_err->GetBuffer().size(), 0);
+}
+
+TEST(InputBuffer, FileReadNonEmptyFile) {
+  TmpFile tmp("cache.bin");
+  constexpr size_t data_size = 42;
+  std::vector<uint8_t> write_data(data_size);
+  std::iota(write_data.begin(), write_data.end(), uint8_t(0));
+  tmp.AppendData(write_data);
+
+  auto buffer_or_err = InputBuffer::Create(
+      tmp.path.c_str(), InputBuffer::ImplementationKind::kFileRead);
+  ASSERT_TRUE(buffer_or_err.ok());
+  ASSERT_EQ(buffer_or_err->GetBufferSize(), data_size);
+  ASSERT_EQ(buffer_or_err->GetBuffer().size(), data_size);
+  for (size_t i = 0; i != data_size; ++i)
+    EXPECT_EQ(buffer_or_err->GetBuffer()[i], write_data[i]);
+}
+
+#if defined(__unix__)
+// Memory mapped input buffers are currently only implemented on unix.
+TEST(InputBuffer, MemMapNotFound) {
+  auto buffer_or_err =
+      InputBuffer::Create("/definitely/nothing/here/perofrmancelayers.bin",
+                          InputBuffer::ImplementationKind::kMemMapped);
+  EXPECT_FALSE(buffer_or_err.ok());
+  SPL_LOG(INFO) << buffer_or_err.status();
+}
+
+TEST(InputBuffer, MemMapEmptyFile) {
+  TmpFile tmp("cache.bin");
+  auto buffer_or_err = InputBuffer::Create(
+      tmp.path.c_str(), InputBuffer::ImplementationKind::kMemMapped);
+  ASSERT_TRUE(buffer_or_err.ok());
+  EXPECT_EQ(buffer_or_err->GetBufferSize(), 0);
+  EXPECT_EQ(buffer_or_err->GetBuffer().size(), 0);
+
+  // Add some data to the underlying file. Since InputBuffer doesn't re-scan
+  // file contents, it should still report an empty buffer.
+  tmp.AppendData(std::vector<uint8_t>(27));
+  ASSERT_TRUE(buffer_or_err.ok());
+  EXPECT_EQ(buffer_or_err->GetBufferSize(), 0);
+  EXPECT_EQ(buffer_or_err->GetBuffer().size(), 0);
+}
+
+TEST(InputBuffer, MemMapNonEmptyFile) {
+  TmpFile tmp("cache.bin");
+  constexpr size_t data_size = 21;
+  std::vector<uint8_t> write_data(data_size);
+  std::iota(write_data.begin(), write_data.end(), uint8_t(0));
+  tmp.AppendData(write_data);
+
+  auto buffer_or_err = InputBuffer::Create(
+      tmp.path.c_str(), InputBuffer::ImplementationKind::kMemMapped);
+  ASSERT_TRUE(buffer_or_err.ok());
+  ASSERT_EQ(buffer_or_err->GetBufferSize(), data_size);
+  ASSERT_EQ(buffer_or_err->GetBuffer().size(), data_size);
+  for (size_t i = 0; i != data_size; ++i)
+    EXPECT_EQ(buffer_or_err->GetBuffer()[i], write_data[i]);
+}
+#endif  // defined(__unix__)
+
+TEST(InputBuffer, DefaultImplNonEmptyFile) {
+  TmpFile tmp("cache.bin");
+  constexpr size_t data_size = 36;
+  std::vector<uint8_t> write_data(data_size);
+  tmp.AppendData(write_data);
+
+  auto buffer_or_err = InputBuffer::Create(tmp.path.c_str());
+  ASSERT_TRUE(buffer_or_err.ok());
+  ASSERT_EQ(buffer_or_err->GetBufferSize(), data_size);
+}
+
+}  // namespace


### PR DESCRIPTION
Provide two concrete implementations:
1. Cross-platform file-based (fopen/fread/fclose).
2. Memory mapped implementation for unix.

Add InputBuffer tests.

This will be used by the cache sideload layer.