### PR TITLE
Add a layer for sideloading pipeline cache files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,16 @@ add_library(VkLayer_stadia_frame_time SHARED
 )
 target_link_libraries(VkLayer_stadia_frame_time PRIVATE performance_layers_support_lib)
 
+add_library(VkLayer_stadia_pipeline_cache_sideload SHARED
+    layer/cache_sideload_layer.cc
+)
+target_link_libraries(VkLayer_stadia_pipeline_cache_sideload PRIVATE performance_layers_support_lib)
+
 install(TARGETS
         VkLayer_stadia_pipeline_compile_time
         VkLayer_stadia_pipeline_runtime
         VkLayer_stadia_frame_time
+        VkLayer_stadia_pipeline_cache_sideload
         DESTINATION lib)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/layer

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -11,5 +11,9 @@ please submit a patch to this file to add yourself.
    * CMake build system support, unit tests, CI, open-source release.
    * Frame time layer log analysis. Event log analysis and timeline view plots.
    * Benchmark start detection.
+   * Logging.
+   * Automatic intercepted layer function registration.
+   * Input buffers.
+   * Pipeline cache sideload layer.
 0. Brian Watling <bwatling@google.com>
    * Frame time layer.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Vulkan Performance Layers
 
-This project contains three Vulkan layers:
+This project contains 4 Vulkan layers:
 1. Compile time layer for measuring pipeline compilation times. The output log file location can be set with the `VK_COMPILE_TIME_LOG` environment variable.
 2. Runtime layer for measuring pipeline execution times. The output log file location can be set with the `VK_RUNTIME_LOG` environment variable.
 3. Frame time layer for measuring time between calls to vkQueuePresentKHR, in nanoseconds. This layer can also terminate the parent Vulkan application after a given number of frames, controlled by the `VK_FRAME_TIME_EXIT_AFTER_FRAME` environment variable. The output log file location can be set with the `VK_FRAME_TIME_LOG` environment variable. Benchmark start detection is controlled by the `VK_FRAME_TIME_BENCHMARK_WATCH_FILE` (which file to incrementally scan) and `VK_FRAME_TIME_BENCHMARK_START_STRING` (string that denotes benchmark start) environment variables.
+4. Pipeline cache sideloading layer for supplying pipeline caches to applications that either do not use pipeline caches, or do not initialize them with the intended initial data. The pipeline cache file to load can be specified by setting the `VK_PIPELINE_CACHE_SIDELOAD_FILE` environment variable. The layer creates an implicit pipeline cache object for each device, initialized with the specified file contents, which then gets merged into application pipeline caches (if any), and makes sure that a valid pipeline cache handle is passed to every pipeline creation. This layer does not produce `.csv` log files.
 
 The results are saved as CSV files. Setting the `VK_PERFORMANCE_LAYERS_EVENT_LOG_FILE` environment variable makes all layers append their events (with timestamps) to a single file.
 

--- a/layer/VkLayer_stadia_pipeline_cache_sideload.json
+++ b/layer/VkLayer_stadia_pipeline_cache_sideload.json
@@ -1,0 +1,22 @@
+
+{
+  "file_format_version" : "1.0.0",
+  "layer" : {
+    "name": "VK_LAYER_STADIA_pipeline_cache_sideload",
+    "type": "GLOBAL",
+    "library_path": "libVkLayer_stadia_pipeline_cache_sideload.so",
+    "api_version": "1.1.74",
+    "implementation_version": "1",
+    "description": "Sideloads Vulkan Pipeline Cache files.",
+    "functions": {
+      "vkGetInstanceProcAddr": "CacheSideloadLayer_GetInstanceProcAddr",
+      "vkGetDeviceProcAddr": "CacheSideloadLayer_GetDeviceProcAddr"
+    },
+    "enable_environment": {
+      "ENABLE_PIPELINE_CACHE_SIDELOAD_LAYER": "1"
+    },
+    "disable_environment": {
+      "DISABLE_PIPELINE_CACHE_SIDELOAD_LAYER": "1"
+    }
+  }
+}

--- a/layer/cache_sideload_layer.cc
+++ b/layer/cache_sideload_layer.cc
@@ -1,0 +1,427 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "absl/container/flat_hash_map.h"
+#include "input_buffer.h"
+#include "layer_data.h"
+#include "layer_utils.h"
+#include "logging.h"
+
+namespace performancelayers {
+namespace {
+class CacheSideloadLayerData : public LayerData {
+ public:
+  CacheSideloadLayerData(const char* pipeline_cache_path)
+      : LayerData(nullptr, ""),
+        implicit_pipeline_cache_path_(pipeline_cache_path) {
+    LogEventOnly("cache_sideload_layer_init");
+  }
+
+  VkPipelineCache GetImplicitDeviceCache(VkDevice) const;
+  VkPipelineCache CreateImplicitDeviceCache(
+      VkDevice device, const VkAllocationCallbacks* alloc_callbacks,
+      absl::Span<const uint8_t> initial_data);
+
+  std::optional<InputBuffer> ReadImplicitCacheFile();
+
+ private:
+  mutable absl::Mutex device_to_implicit_cache_handle_lock_;
+  absl::flat_hash_map<VkDevice, VkPipelineCache>
+      device_to_implicit_cache_handle_
+          ABSL_GUARDED_BY(device_to_implicit_cache_handle_lock_);
+
+  const char* implicit_pipeline_cache_path_ = nullptr;
+};
+
+VkPipelineCache CacheSideloadLayerData::GetImplicitDeviceCache(
+    VkDevice device) const {
+  absl::MutexLock lock(&device_to_implicit_cache_handle_lock_);
+  if (auto it = device_to_implicit_cache_handle_.find(device);
+      it != device_to_implicit_cache_handle_.end())
+    return it->second;
+
+  return nullptr;
+}
+
+VkPipelineCache CacheSideloadLayerData::CreateImplicitDeviceCache(
+    VkDevice device, const VkAllocationCallbacks* alloc_callbacks,
+    absl::Span<const uint8_t> initial_data) {
+  absl::MutexLock lock(&device_to_implicit_cache_handle_lock_);
+  assert(device_to_implicit_cache_handle_.count(device) == 0 &&
+         "Implicit cache already created for this device.");
+
+  VkPipelineCacheCreateInfo create_info = {};
+  create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+  create_info.initialDataSize = initial_data.size();
+  create_info.pInitialData = initial_data.data();
+
+  const std::string path_info =
+      absl::StrCat("path: ", implicit_pipeline_cache_path_);
+  const std::string size_info = absl::StrCat("size: ", initial_data.size());
+
+  auto create_proc =
+      GetNextDeviceProcAddr(device, &VkLayerDispatchTable::CreatePipelineCache);
+  VkPipelineCache new_cache = nullptr;
+  const VkResult result =
+      create_proc(device, &create_info, alloc_callbacks, &new_cache);
+  if (result != VK_SUCCESS) {
+    SPL_LOG(ERROR) << "Failed to create implicit pipeline cache (" << path_info
+                   << ", " << size_info << ")";
+    return nullptr;
+  }
+
+  // Insert only valid pipeline cache handles.
+  device_to_implicit_cache_handle_[device] = new_cache;
+
+  SPL_LOG(INFO) << "Create implicit pipeline cache (" << path_info << ", "
+                << size_info << ")";
+  LogEventOnly("create_implicit_pipeline_cache", CsvCat(path_info, size_info));
+  return new_cache;
+}
+
+std::optional<InputBuffer> CacheSideloadLayerData::ReadImplicitCacheFile() {
+  if (!implicit_pipeline_cache_path_ ||
+      strlen(implicit_pipeline_cache_path_) == 0) {
+    SPL_LOG(WARNING) << "Invalid implicit pipeline cache file path";
+    return std::nullopt;
+  }
+
+  auto cache_file_or_status =
+      performancelayers::InputBuffer::Create(implicit_pipeline_cache_path_);
+  if (!cache_file_or_status.ok()) {
+    SPL_LOG(ERROR) << "Failed to read implicit pipeline cache: "
+                   << cache_file_or_status.status();
+    return std::nullopt;
+  }
+  return std::move(*cache_file_or_status);
+}
+
+}  // namespace
+}  // namespace performancelayers
+
+namespace {
+
+// ----------------------------------------------------------------------------
+// Layer book-keeping information
+// ----------------------------------------------------------------------------
+constexpr uint32_t kCacheSideloadLayerVersion = 1;
+
+constexpr char kLayerName[] = "VK_LAYER_STADIA_pipeline_cache_sideload";
+constexpr char kLayerDescription[] = "Stadia Pipeline Cache Sideloading Layer";
+constexpr char kImplicitCacheFilenameEnvVar[] =
+    "VK_PIPELINE_CACHE_SIDELOAD_FILE";
+
+performancelayers::CacheSideloadLayerData* GetLayerData() {
+  // Don't use new -- make the destructor run when the layer gets unloaded.
+  static performancelayers::CacheSideloadLayerData layer_data =
+      performancelayers::CacheSideloadLayerData(
+          getenv(kImplicitCacheFilenameEnvVar));
+  return &layer_data;
+}
+
+// Use this macro to define all vulkan functions intercepted by the layer.
+#define SPL_CACHE_SIDELOAD_LAYER_FUNC(RETURN_TYPE_, FUNC_NAME_, FUNC_ARGS_)  \
+  SPL_INTERCEPTED_VULKAN_FUNC(RETURN_TYPE_, CacheSideloadLayer_, FUNC_NAME_, \
+                              FUNC_ARGS_)
+
+//////////////////////////////////////////////////////////////////////////////
+//  Implementation of the instance functions we want to override.
+//////////////////////////////////////////////////////////////////////////////
+
+// Override for vkDestroyInstance. Deletes the entry for |instance| from the
+// layer data.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(void, DestroyInstance,
+                              (VkInstance instance,
+                               const VkAllocationCallbacks* allocator)) {
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+  auto next_proc = layer_data->GetNextInstanceProcAddr(
+      instance, &VkLayerInstanceDispatchTable::DestroyInstance);
+  next_proc(instance, allocator);
+  layer_data->RemoveInstance(instance);
+}
+
+// Override for vkCreateInstance. Creates the dispatch table for this instance
+// and add it to the layer data.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, CreateInstance,
+                              (const VkInstanceCreateInfo* create_info,
+                               const VkAllocationCallbacks* allocator,
+                               VkInstance* instance)) {
+  auto build_dispatch_table =
+      [instance](PFN_vkGetInstanceProcAddr get_proc_addr) {
+        // Build dispatch table for the instance functions we need to call.
+        VkLayerInstanceDispatchTable dispatch_table{};
+
+        // Get the next layer's instance of the instance functions we will
+        // override.
+        SPL_DISPATCH_INSTANCE_FUNC(DestroyInstance);
+        SPL_DISPATCH_INSTANCE_FUNC(EnumeratePhysicalDevices);
+        SPL_DISPATCH_INSTANCE_FUNC(GetInstanceProcAddr);
+
+        return dispatch_table;
+      };
+
+  return GetLayerData()->CreateInstance(create_info, allocator, instance,
+                                        build_dispatch_table);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//  Implementation of the device function we want to override.
+//////////////////////////////////////////////////////////////////////////////
+
+// Override for vkCreateComputePipelines. Provides implicit device pipeline
+// cache when the application does not provide a pipeline cache object.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, CreateComputePipelines,
+                              (VkDevice device, VkPipelineCache pipeline_cache,
+                               uint32_t create_info_count,
+                               const VkComputePipelineCreateInfo* create_infos,
+                               const VkAllocationCallbacks* alloc_callbacks,
+                               VkPipeline* pipelines)) {
+  assert(create_info_count > 0 &&
+         "Spececification says create_info_count must be > 0.");
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+
+  auto actual_cache = pipeline_cache
+                          ? pipeline_cache
+                          : layer_data->GetImplicitDeviceCache(device);
+
+  auto next_proc = layer_data->GetNextDeviceProcAddr(
+      device, &VkLayerDispatchTable::CreateComputePipelines);
+  return next_proc(device, actual_cache, create_info_count, create_infos,
+                   alloc_callbacks, pipelines);
+}
+
+// Override for vkCreateGraphicsPipelines. Provides implicit device pipeline
+// cache when the application does not provide a pipeline cache object.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, CreateGraphicsPipelines,
+                              (VkDevice device, VkPipelineCache pipeline_cache,
+                               uint32_t create_info_count,
+                               const VkGraphicsPipelineCreateInfo* create_infos,
+                               const VkAllocationCallbacks* alloc_callbacks,
+                               VkPipeline* pipelines)) {
+  assert(create_info_count > 0 &&
+         "Spececification says create_info_count must be > 0.");
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+
+  auto actual_cache = pipeline_cache
+                          ? pipeline_cache
+                          : layer_data->GetImplicitDeviceCache(device);
+
+  auto next_proc = layer_data->GetNextDeviceProcAddr(
+      device, &VkLayerDispatchTable::CreateGraphicsPipelines);
+  return next_proc(device, actual_cache, create_info_count, create_infos,
+                   alloc_callbacks, pipelines);
+}
+
+// Override for vkCreatePipelineCache. Merges the implicit device pipeline
+// cache into the newly created application cache. Reports merge failures as
+// creation failures.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, CreatePipelineCache,
+                              (VkDevice device,
+                               const VkPipelineCacheCreateInfo* create_info,
+                               const VkAllocationCallbacks* alloc_callbacks,
+                               VkPipelineCache* pipeline_cache)) {
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+  auto next_proc = layer_data->GetNextDeviceProcAddr(
+      device, &VkLayerDispatchTable::CreatePipelineCache);
+
+  const VkResult create_result =
+      next_proc(device, create_info, alloc_callbacks, pipeline_cache);
+
+  if (create_result == VK_SUCCESS) {
+    assert(*pipeline_cache);
+    if (VkPipelineCache implicit_cache =
+            layer_data->GetImplicitDeviceCache(device)) {
+      auto merge_cache_proc = layer_data->GetNextDeviceProcAddr(
+          device, &VkLayerDispatchTable::MergePipelineCaches);
+      const VkResult merge_result =
+          merge_cache_proc(device, *pipeline_cache, 1, &implicit_cache);
+
+      const std::string merge_result_str = absl::StrCat(
+          "result: ", (merge_result == VK_SUCCESS) ? "success" : "failure");
+      SPL_LOG(INFO) << "Application pipeline cache merge with implicit cache ("
+                    << merge_result_str << ")";
+      layer_data->LogEventOnly("merge_implicit_pipeline_cache",
+                               merge_result_str);
+
+      return merge_result;
+    }
+  }
+
+  return create_result;
+}
+
+// Override for vkGetPipelineCacheData. Checks that application does not
+// request pipeline cache data for implicit device pipeline caches.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, GetPipelineCacheData,
+                              (VkDevice device, VkPipelineCache cache,
+                               size_t* data_size, void* data_out)) {
+  assert(data_size &&
+         "According to the spec, data size must be a valid pointer.");
+  assert(cache &&
+         "According to the spec, pipeline cache must be a valid handle.");
+
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+  auto next_proc = layer_data->GetNextDeviceProcAddr(
+      device, &VkLayerDispatchTable::GetPipelineCacheData);
+
+  if (cache == layer_data->GetImplicitDeviceCache(device)) {
+    SPL_LOG(ERROR)
+        << "Application unexpectedly passed a handle to an implicit "
+           "pipeline cache managed by the Pipeline Cache Sideload layer";
+    *data_size = 0;
+    return VK_INCOMPLETE;
+  }
+
+  return next_proc(device, cache, data_size, data_out);
+}
+
+// Override fro vkEnumeratePhysicalDevices. Maps physical devices to their
+// instances. This mapping is used in the vkCreateDevice override.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, EnumeratePhysicalDevices,
+                              (VkInstance instance,
+                               uint32_t* pPhysicalDeviceCount,
+                               VkPhysicalDevice* pPhysicalDevices)) {
+  return GetLayerData()->EnumeratePhysicalDevices(
+      instance, pPhysicalDeviceCount, pPhysicalDevices);
+}
+
+// Override for vkDestroyDevice. Removes the dispatch table for the device from
+// the layer data.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(void, DestroyDevice,
+                              (VkDevice device,
+                               const VkAllocationCallbacks* allocator)) {
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+  auto next_proc = layer_data->GetNextDeviceProcAddr(
+      device, &VkLayerDispatchTable::DestroyDevice);
+  next_proc(device, allocator);
+  layer_data->RemoveDevice(device);
+}
+
+// Override for vkCreateDevice. Builds the dispatch table for the new device
+// and add it to the layer data. Creates an implicit layer-managed pipeline
+// for each device. This cache is pre-populated with the implicit pipeline
+// cache file.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, CreateDevice,
+                              (VkPhysicalDevice physical_device,
+                               const VkDeviceCreateInfo* create_info,
+                               const VkAllocationCallbacks* allocator,
+                               VkDevice* device)) {
+  auto build_dispatch_table = [device](PFN_vkGetDeviceProcAddr gdpa) {
+    VkLayerDispatchTable dispatch_table{};
+
+    // Get the next layer's instance of the device functions we will override.
+    SPL_DISPATCH_DEVICE_FUNC(GetDeviceProcAddr);
+    SPL_DISPATCH_DEVICE_FUNC(DestroyDevice);
+    SPL_DISPATCH_DEVICE_FUNC(CreateComputePipelines);
+    SPL_DISPATCH_DEVICE_FUNC(CreateGraphicsPipelines);
+    SPL_DISPATCH_DEVICE_FUNC(CreatePipelineCache);
+    SPL_DISPATCH_DEVICE_FUNC(GetPipelineCacheData);
+    // Get the next layer's instance of the device functions we will use. We do
+    // not call these Vulkan functions directly to avoid re-entering the Vulkan
+    // loader and confusing it.
+    SPL_DISPATCH_DEVICE_FUNC(MergePipelineCaches);
+
+    return dispatch_table;
+  };
+
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+  const VkResult create_device_result = layer_data->CreateDevice(
+      physical_device, create_info, allocator, device, build_dispatch_table);
+  if (create_device_result == VK_SUCCESS) {
+    assert(*device && "Device not created?");
+    if (auto cache_blob_or_none = layer_data->ReadImplicitCacheFile()) {
+      auto implicit_cache_handle = layer_data->CreateImplicitDeviceCache(
+          *device, allocator, cache_blob_or_none->GetBuffer());
+      (void)implicit_cache_handle;
+    }
+  }
+
+  return create_device_result;
+}
+
+// Override for vkEnumerateInstanceLayerProperties.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, EnumerateInstanceLayerProperties,
+                              (uint32_t * property_count,
+                               VkLayerProperties* properties)) {
+  if (property_count) *property_count = 1;
+
+  if (properties) {
+    strncpy(properties->layerName, kLayerName, sizeof(properties->layerName));
+    strncpy(properties->description, kLayerDescription,
+            sizeof(properties->description));
+    properties->implementationVersion = kCacheSideloadLayerVersion;
+    properties->specVersion = VK_API_VERSION_1_0;
+  }
+
+  return VK_SUCCESS;
+}
+
+// Override for vkEnumerateDeviceLayerProperties.
+SPL_CACHE_SIDELOAD_LAYER_FUNC(VkResult, EnumerateDeviceLayerProperties,
+                              (VkPhysicalDevice /* physical_device */,
+                               uint32_t* property_count,
+                               VkLayerProperties* properties)) {
+  return CacheSideloadLayer_EnumerateInstanceLayerProperties(property_count,
+                                                             properties);
+}
+
+}  // namespace
+
+// The *GetProcAddr functions are the entry points to the layers.
+// They return a function pointer for the instance requested by |name|.
+// We return the functions defined in this layer for those we want to override.
+// Otherwise we call the *GetProcAddr function for the next layer to get the
+// function to be called.
+
+SPL_LAYER_ENTRY_POINT SPL_CACHE_SIDELOAD_LAYER_FUNC(PFN_vkVoidFunction,
+                                                    GetDeviceProcAddr,
+                                                    (VkDevice device,
+                                                     const char* name)) {
+  if (auto func =
+          performancelayers::FunctionInterceptor::GetInterceptedOrNull(name)) {
+    return func;
+  }
+
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+
+  PFN_vkGetDeviceProcAddr next_get_proc_addr =
+      layer_data->GetNextDeviceProcAddr(
+          device, &VkLayerDispatchTable::GetDeviceProcAddr);
+  assert(next_get_proc_addr);
+  return next_get_proc_addr(device, name);
+}
+
+SPL_LAYER_ENTRY_POINT SPL_CACHE_SIDELOAD_LAYER_FUNC(PFN_vkVoidFunction,
+                                                    GetInstanceProcAddr,
+                                                    (VkInstance instance,
+                                                     const char* name)) {
+  if (auto func =
+          performancelayers::FunctionInterceptor::GetInterceptedOrNull(name)) {
+    return func;
+  }
+
+  performancelayers::CacheSideloadLayerData* layer_data = GetLayerData();
+
+  PFN_vkGetInstanceProcAddr next_get_proc_addr =
+      layer_data->GetNextInstanceProcAddr(
+          instance, &VkLayerInstanceDispatchTable::GetInstanceProcAddr);
+  assert(next_get_proc_addr);
+  return next_get_proc_addr(instance, name);
+}

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -14,15 +14,12 @@
 
 #include "layer_data.h"
 
-#include <inttypes.h>
-
+#include <cinttypes>
 #include <cstdint>
-#include <tuple>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/str_join.h"
 #include "absl/synchronization/mutex.h"
 #include "layer_utils.h"
 #include "logging.h"
@@ -39,12 +36,6 @@ void WriteLnAndFlush(FILE* file, const std::string& content) {
   fflush(file);
 }
 
-// Joins all |args| with the ',' CSV separator.
-template <typename... Args>
-std::string CsvCat(Args&&... args) {
-  return absl::StrJoin(std::forward_as_tuple(std::forward<Args>(args)...), ",");
-}
-
 // Returns a quoted string.
 template <typename StrTy>
 std::string QuoteStr(StrTy&& str) {
@@ -55,7 +46,7 @@ std::string QuoteStr(StrTy&& str) {
 // |timestamp|.
 std::string MakeEventLogPrefix(const char* event_type,
                                absl::Time timestamp = absl::Now()) {
-  return CsvCat(event_type, absl::ToUnixNanos(timestamp));
+  return performancelayers::CsvCat(event_type, absl::ToUnixNanos(timestamp));
 }
 
 // Returns the first create info of type

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -19,9 +19,11 @@
 #include <cstdio>
 #include <functional>
 #include <set>
+#include <tuple>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_join.h"
 #include "absl/synchronization/mutex.h"
 #include "farmhash.h"
 #include "vulkan/vk_layer.h"
@@ -32,6 +34,12 @@
 #include "vk_layer_dispatch_table.h"
 
 namespace performancelayers {
+
+// Joins all |args| with the ',' CSV separator.
+template <typename... Args>
+std::string CsvCat(Args&&... args) {
+  return absl::StrJoin(std::forward_as_tuple(std::forward<Args>(args)...), ",");
+}
 
 // A class that contains all of the data that is needed for the functions
 // that this layer will override.


### PR DESCRIPTION
Pipeline cache sideload layer supplies pipeline caches to applications
that either do not use pipeline caches, or do not initialize them with
the intended initial data.

The pipeline cache file to load can be specified by setting the
`VK_PIPELINE_CACHE_SIDELOAD_FILE` environment variable.

The layer creates an implicit pipeline cache object for each device,
initialized with the specified file contents. This implicit cache then
gets merged into application pipeline caches (if any). The layer makes
sure that a valid pipeline cache handle is passed to every pipelien
creation.

This layer does not produce `.csv` log files.