### PR TITLE
New helper class QueueToDeviceMap.

### DIFF
--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -69,15 +69,18 @@ class FrameTimeLayerData : public performancelayers::LayerData {
 
   void GetDeviceQueue(VkDevice device, uint32_t queue_family_index,
                       uint32_t queue_index, VkQueue* queue) {
-    queue_to_device_map_.GetDeviceQueue(this, device, queue_family_index, queue_index, queue);
+    queue_to_device_map_.GetDeviceQueue(this, device, queue_family_index,
+                                        queue_index, queue);
   }
 
-  void GetDeviceQueue2(VkDevice device,
-                       const VkDeviceQueueInfo2* queue_info, VkQueue* queue) {
+  void GetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* queue_info,
+                       VkQueue* queue) {
     queue_to_device_map_.GetDeviceQueue2(this, device, queue_info, queue);
   }
 
-  VkDevice GetDevice(VkQueue queue) { return queue_to_device_map_.GetDevice(queue); }
+  VkDevice GetDevice(VkQueue queue) {
+    return queue_to_device_map_.GetDevice(queue);
+  }
 
   static constexpr uint64_t kInvalidFrameNum = ~uint64_t(0);
 
@@ -202,7 +205,8 @@ SPL_FRAME_TIME_LAYER_FUNC(VkResult, QueuePresentKHR,
 SPL_FRAME_TIME_LAYER_FUNC(void, GetDeviceQueue,
                           (VkDevice device, uint32_t queue_family_index,
                            uint32_t queue_index, VkQueue* queue)) {
-  GetLayerData()->GetDeviceQueue(device, queue_family_index, queue_index, queue);
+  GetLayerData()->GetDeviceQueue(device, queue_family_index, queue_index,
+                                 queue);
 }
 
 SPL_FRAME_TIME_LAYER_FUNC(void, GetDeviceQueue2,

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -296,7 +296,7 @@ VkResult LayerData::CreateShaderModule(
 VkDevice QueueToDeviceMap::GetDevice(VkQueue queue) const {
   absl::MutexLock lock(&queue_to_device_lock_);
   const auto it = queue_to_device_.find(queue);
-  assert (it != queue_to_device_.end());
+  assert(it != queue_to_device_.end());
   return it->second;
 }
 
@@ -305,8 +305,9 @@ void QueueToDeviceMap::SetDevice(VkQueue queue, VkDevice device) {
   queue_to_device_.insert_or_assign(queue, device);
 }
 
-void QueueToDeviceMap::GetDeviceQueue(LayerData* layer_data, VkDevice device, uint32_t queue_family_index,
-                                       uint32_t queue_index, VkQueue* queue) {
+void QueueToDeviceMap::GetDeviceQueue(LayerData* layer_data, VkDevice device,
+                                      uint32_t queue_family_index,
+                                      uint32_t queue_index, VkQueue* queue) {
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::GetDeviceQueue);
   (next_proc)(device, queue_family_index, queue_index, queue);
@@ -316,8 +317,8 @@ void QueueToDeviceMap::GetDeviceQueue(LayerData* layer_data, VkDevice device, ui
 }
 
 void QueueToDeviceMap::GetDeviceQueue2(LayerData* layer_data, VkDevice device,
-                                       const VkDeviceQueueInfo2* queue_info, VkQueue* queue)
-{
+                                       const VkDeviceQueueInfo2* queue_info,
+                                       VkQueue* queue) {
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::GetDeviceQueue2);
   (next_proc)(device, queue_info, queue);

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -277,8 +277,9 @@ class QueueToDeviceMap {
 
   // Intended to be called from an overridden vkGetDeviceQueue. Calls the next
   // layer, and records the result.
-  void GetDeviceQueue(LayerData* layer_data, VkDevice device, uint32_t queue_family_index,
-                               uint32_t queue_index, VkQueue* queue);
+  void GetDeviceQueue(LayerData* layer_data, VkDevice device,
+                      uint32_t queue_family_index, uint32_t queue_index,
+                      VkQueue* queue);
   // Intended to be called from an overridden vkGetDeviceQueue2. Calls the next
   // layer, and records the result.
   void GetDeviceQueue2(LayerData* layer_data, VkDevice device,
@@ -289,7 +290,6 @@ class QueueToDeviceMap {
   // The map from a queue to the device that owns it.
   absl::flat_hash_map<VkQueue, VkDevice> queue_to_device_
       ABSL_GUARDED_BY(queue_to_device_lock_);
-
 };
 
 }  // namespace performancelayers

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -266,6 +266,32 @@ class LayerData {
   // Event log file appended to by multiple layers, or nullptr.
   FILE* event_log_ = nullptr;
 };
+
+class QueueToDeviceMap {
+ public:
+  // Records the device that owns |queue|.
+  void SetDevice(VkQueue queue, VkDevice device);
+
+  // Returns the device that owns |queue|.
+  VkDevice GetDevice(VkQueue queue) const;
+
+  // Intended to be called from an overridden vkGetDeviceQueue. Calls the next
+  // layer, and records the result.
+  void GetDeviceQueue(LayerData* layer_data, VkDevice device, uint32_t queue_family_index,
+                               uint32_t queue_index, VkQueue* queue);
+  // Intended to be called from an overridden vkGetDeviceQueue2. Calls the next
+  // layer, and records the result.
+  void GetDeviceQueue2(LayerData* layer_data, VkDevice device,
+                       const VkDeviceQueueInfo2* queue_info, VkQueue* queue);
+
+ private:
+  mutable absl::Mutex queue_to_device_lock_;
+  // The map from a queue to the device that owns it.
+  absl::flat_hash_map<VkQueue, VkDevice> queue_to_device_
+      ABSL_GUARDED_BY(queue_to_device_lock_);
+
+};
+
 }  // namespace performancelayers
 
 #endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LAYER_DATA_H_

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -351,12 +351,13 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, QueueWaitIdle, (VkQueue queue)) {
 SPL_RUNTIME_LAYER_FUNC(void, GetDeviceQueue,
                        (VkDevice device, uint32_t queue_family_index,
                         uint32_t queue_index, VkQueue* queue)) {
-  performancelayers::RuntimeLayerData* layer_data = GetLayerData();
-  auto next_proc = layer_data->GetNextDeviceProcAddr(
-      device, &VkLayerDispatchTable::GetDeviceQueue);
-  (next_proc)(device, queue_family_index, queue_index, queue);
+  GetLayerData()->GetDeviceQueue(device, queue_family_index, queue_index, queue);
+}
 
-  layer_data->SetDevice(*queue, device);
+SPL_RUNTIME_LAYER_FUNC(void, GetDeviceQueue2,
+                       (VkDevice device, const VkDeviceQueueInfo2* queue_info,
+                        VkQueue* queue)) {
+  GetLayerData()->GetDeviceQueue2(device, queue_info, queue);
 }
 
 // Override for vkCreateShaderModule.  Records the hash of the shader module in
@@ -417,6 +418,7 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, CreateDevice,
     SPL_DISPATCH_DEVICE_FUNC(CmdDrawIndexedIndirect);
     SPL_DISPATCH_DEVICE_FUNC(QueueWaitIdle);
     SPL_DISPATCH_DEVICE_FUNC(GetDeviceQueue);
+    SPL_DISPATCH_DEVICE_FUNC(GetDeviceQueue2);
     // Get the next layer's instance of the device functions we will use. We do
     // not call these Vulkan functions directly to avoid re-entering the Vulkan
     // loader and confusing it.

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -351,7 +351,8 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, QueueWaitIdle, (VkQueue queue)) {
 SPL_RUNTIME_LAYER_FUNC(void, GetDeviceQueue,
                        (VkDevice device, uint32_t queue_family_index,
                         uint32_t queue_index, VkQueue* queue)) {
-  GetLayerData()->GetDeviceQueue(device, queue_family_index, queue_index, queue);
+  GetLayerData()->GetDeviceQueue(device, queue_family_index, queue_index,
+                                 queue);
 }
 
 SPL_RUNTIME_LAYER_FUNC(void, GetDeviceQueue2,

--- a/layer/runtime_layer_data.h
+++ b/layer/runtime_layer_data.h
@@ -58,8 +58,9 @@ class RuntimeLayerData : public LayerData {
   }
 
   void GetDeviceQueue(VkDevice device, uint32_t queue_family_index,
-                            uint32_t queue_index, VkQueue* queue) {
-    queue_to_device_map_.GetDeviceQueue(this, device, queue_family_index, queue_index, queue);
+                      uint32_t queue_index, VkQueue* queue) {
+    queue_to_device_map_.GetDeviceQueue(this, device, queue_family_index,
+                                        queue_index, queue);
   }
 
   void GetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* queue_info,
@@ -67,7 +68,9 @@ class RuntimeLayerData : public LayerData {
     queue_to_device_map_.GetDeviceQueue2(this, device, queue_info, queue);
   }
 
-  VkDevice GetDevice(VkQueue queue) { return queue_to_device_map_.GetDevice(queue); }
+  VkDevice GetDevice(VkQueue queue) {
+    return queue_to_device_map_.GetDevice(queue);
+  }
 
   // Records |pipeline| as the latest pipeline that has been bound to
   // |cmd_buffer|.


### PR DESCRIPTION
Shared between the frame_time and runtime layers, without growing the
LayerData class. Intend to use also for the memory_usage layer. Also
fix runtime layer to use separate type-safe maps for VkCommandBuffer
and VkQueue, rather than a map keyed by void*.