### PR TITLE
Report cmake Vulkan configuration errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,21 +31,32 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 add_subdirectory(third_party)
 
 if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
+  if(NOT IS_ABSOLUTE "${VULKAN_HEADERS_INSTALL_DIR}")
+    message(FATAL_ERROR "VULKAN_HEADERS_INSTALL_DIR must be an absolute path")
+  endif()
   find_path(VulkanHeaders_INCLUDE_DIR
       NAMES vulkan/vk_layer.h
       HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
       NO_CMAKE_FIND_ROOT_PATH)
+  if(VulkanHeaders_INCLUDE_DIR MATCHES ".*_INCLUDE_DIR-NOTFOUND$")
+    message(FATAL_ERROR "Vulkan Headers not found. Set VULKAN_HEADERS_INSTALL_DIR to the Vulkan-Headers installation directory.")
+  endif()
 else()
   message(FATAL_ERROR "VULKAN_HEADERS_INSTALL_DIR must be specified!")
 endif()
-
 message(STATUS "VulkanHeaders ${VulkanHeaders_INCLUDE_DIR}")
 
 if(DEFINED VULKAN_LOADER_GENERATED_DIR)
+  if(NOT IS_ABSOLUTE "${VULKAN_LOADER_GENERATED_DIR}")
+    message(FATAL_ERROR "VULKAN_LOADER_GENERATED_DIR must be an absolute path")
+  endif()
   find_path(VulkanLoaderGenerated_INCLUDE_DIR
       NAMES vk_layer_dispatch_table.h
       HINTS ${VULKAN_LOADER_GENERATED_DIR}
       NO_CMAKE_FIND_ROOT_PATH)
+  if(VulkanLoaderGenerated_INCLUDE_DIR MATCHES ".*_INCLUDE_DIR-NOTFOUND$")
+    message(FATAL_ERROR "Vulkan Loader sources not found. Set VULKAN_LOADER_GENERATED_DIR to the 'Vulkan-Loader/loader/generated' directory.")
+  endif()
 else()
   message(FATAL_ERROR "VULKAN_LOADER_GENERATED_DIR must be specified!")
 endif()

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find more details in the descriptions included in each script file.
 
 Sample build instructions:
 
-```
+```shell
 # Checkout the submodules.
 git submodule update --init
 
@@ -42,9 +42,22 @@ cmake .. \
     && ninja install
 ```
 
+NOTE: `VULKAN_HEADERS_INSTALL_DIR` and `VULKAN_LOADER_GENERATED_DIR` must be absolute paths.
+
+NOTE: `VULKAN_HEADERS_INSTALL_DIR` must be set to the installation directory of Vulkan-Headers. For example, if you build directory is `VULKAN_HEADERS_BUILD` and your build commands were:
+
+   ```shell
+   cmake <PATH_TO_VULKAN_HEADERS> -GNinja -DCMAKE_INSTALL_PREFIX=run
+   ninja
+   ninja install
+   ```
+
+   you should set `VULKAN_HEADERS_INSTALL_DIR` to `VULKAN_HEADERS_BUILD/run`.
+
+NOTE: `VULKAN_LOADER_GENERATED_DIR` should be the directory that contains `vk_layer_dispatch_table.h`. For example, if you cloned Vulkan-Loader to `PATH_TO_VULKAN_LOADER`, you should set `VULKAN_LOADER_GENERATED_DIR` to `PATH_TO_VULKAN_LOADER/loader/generated`.
+
 See [docker/build.Dockerfile](docker/build.Dockerfile) for detailed Ubuntu build instructions.
 
 ## Disclaimer
 
 This is not an officially supported Google product. Support and/or new releases may be limited.
-


### PR DESCRIPTION
... when `VULKAN_HEADERS_INSTALL_DIR` or `VULKAN_LOADER_GENERATED_DIR`
are set incorrectly.

Clarify build instructions.