### PR TITLE
Avoid heap allocations in layer data. NFC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ target_include_directories(performance_layers_support_lib INTERFACE
 target_link_libraries(performance_layers_support_lib INTERFACE
     absl::flat_hash_map
     absl::flat_hash_set
+    absl::inlined_vector
     absl::status
     absl::statusor
     absl::strings

--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <string>
@@ -33,16 +34,17 @@ constexpr char kLayerDescription[] =
     "Stadia Pipeline Compile Time Measuring Layer";
 constexpr char kLogFilenameEnvVar[] = "VK_COMPILE_TIME_LOG";
 
-performancelayers::LayerData* GetLayerData() {
-  // Don't use new -- make the destructor run when the layer gets unloaded.
-  static performancelayers::LayerData layer_data = performancelayers::LayerData(
-      getenv(kLogFilenameEnvVar), "Pipeline,Compile Time (ns)");
-  static bool first_call = true;
-  if (first_call) {
-    layer_data.LogEventOnly("compile_time_layer_init");
-    first_call = false;
+class CompileTimeLayerData : public performancelayers::LayerData {
+ public:
+  CompileTimeLayerData(char* log_filename)
+      : LayerData(log_filename, "Pipeline,Compile Time (ns)") {
+    LogEventOnly("compile_time_layer_init");
   }
+};
 
+CompileTimeLayerData* GetLayerData() {
+  // Don't use new -- make the destructor run when the layer gets unloaded.
+  static CompileTimeLayerData layer_data(getenv(kLogFilenameEnvVar));
   return &layer_data;
 }
 
@@ -60,7 +62,7 @@ performancelayers::LayerData* GetLayerData() {
 SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyInstance,
                             (VkInstance instance,
                              const VkAllocationCallbacks* allocator)) {
-  performancelayers::LayerData* layer_data = GetLayerData();
+  CompileTimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextInstanceProcAddr(
       instance, &VkLayerInstanceDispatchTable::DestroyInstance);
   next_proc(instance, allocator);
@@ -101,7 +103,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateComputePipelines,
                              const VkComputePipelineCreateInfo* create_infos,
                              const VkAllocationCallbacks* alloc_callbacks,
                              VkPipeline* pipelines)) {
-  performancelayers::LayerData* layer_data = GetLayerData();
+  CompileTimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::CreateComputePipelines);
 
@@ -114,13 +116,12 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateComputePipelines,
   absl::Time end = absl::Now();
   uint64_t duration = ToInt64Nanoseconds(end - start);
 
-  std::vector<uint64_t> hashes;
+  performancelayers::LayerData::HashVector hashes;
   for (uint32_t i = 0; i < create_info_count; ++i) {
-    std::vector<uint64_t> h =
-        layer_data->HashComputePipeline(pipelines[i], create_infos[i]);
+    auto h = layer_data->HashComputePipeline(pipelines[i], create_infos[i]);
     hashes.insert(hashes.end(), h.begin(), h.end());
   }
-  layer_data->Log("create_compute_pipeline", hashes, duration);
+  layer_data->Log("create_compute_pipelines", hashes, duration);
   return result;
 }
 
@@ -132,7 +133,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateGraphicsPipelines,
                              const VkGraphicsPipelineCreateInfo* create_infos,
                              const VkAllocationCallbacks* alloc_callbacks,
                              VkPipeline* pipelines)) {
-  performancelayers::LayerData* layer_data = GetLayerData();
+  CompileTimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::CreateGraphicsPipelines);
 
@@ -145,13 +146,12 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateGraphicsPipelines,
   auto end = absl::Now();
   uint64_t duration = ToInt64Nanoseconds(end - start);
 
-  std::vector<uint64_t> hashes;
-  for (uint32_t i = 0; i < create_info_count; i++) {
-    std::vector<uint64_t> h =
-        layer_data->HashGraphicsPipeline(pipelines[i], create_infos[i]);
+  performancelayers::LayerData::HashVector hashes;
+  for (uint32_t i = 0; i < create_info_count; ++i) {
+    auto h = layer_data->HashGraphicsPipeline(pipelines[i], create_infos[i]);
     hashes.insert(hashes.end(), h.begin(), h.end());
   }
-  layer_data->Log("create_graphics_pipeline", hashes, duration);
+  layer_data->Log("create_graphics_pipelines", hashes, duration);
   return result;
 }
 
@@ -171,7 +171,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateShaderModule,
 SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyDevice,
                             (VkDevice device,
                              const VkAllocationCallbacks* allocator)) {
-  performancelayers::LayerData* layer_data = GetLayerData();
+  CompileTimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::DestroyDevice);
   next_proc(device, allocator);
@@ -242,7 +242,7 @@ SPL_LAYER_ENTRY_POINT SPL_COMPILE_TIME_LAYER_FUNC(PFN_vkVoidFunction,
     return func;
   }
 
-  performancelayers::LayerData* layer_data = GetLayerData();
+  CompileTimeLayerData* layer_data = GetLayerData();
 
   PFN_vkGetDeviceProcAddr next_get_proc_addr =
       layer_data->GetNextDeviceProcAddr(
@@ -260,7 +260,7 @@ SPL_LAYER_ENTRY_POINT SPL_COMPILE_TIME_LAYER_FUNC(PFN_vkVoidFunction,
     return func;
   }
 
-  performancelayers::LayerData* layer_data = GetLayerData();
+  CompileTimeLayerData* layer_data = GetLayerData();
 
   PFN_vkGetInstanceProcAddr next_get_proc_addr =
       layer_data->GetNextInstanceProcAddr(

--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -29,7 +29,9 @@ constexpr char kLogFilenameEnvVar[] = "VK_MEMORY_USAGE_LOG";
 class MemoryUsageLayerData : public performancelayers::LayerData {
  public:
   explicit MemoryUsageLayerData(char* log_filename)
-      : LayerData(log_filename, "Current (bytes), peak (bytes)") {}
+      : LayerData(log_filename, "Current (bytes), peak (bytes)") {
+    LogEventOnly("memory_usage_layer_init");
+  }
 
   void RecordAllocateMemory(VkDevice device, VkDeviceMemory memory,
                             VkDeviceSize size) {
@@ -89,12 +91,6 @@ class MemoryUsageLayerData : public performancelayers::LayerData {
 MemoryUsageLayerData* GetLayerData() {
   // Don't use new -- make the destructor run when the layer gets unloaded.
   static MemoryUsageLayerData layer_data(getenv(kLogFilenameEnvVar));
-  static bool first_call = true;
-  if (first_call) {
-    layer_data.LogEventOnly("memory_usage_layer_init");
-    first_call = false;
-  }
-
   return &layer_data;
 }
 

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -100,7 +100,7 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, CreateComputePipelines,
       device, &VkLayerDispatchTable::CreateComputePipelines);
 
   assert(create_info_count > 0 &&
-         "Spececification says create_info_count must be > 0.");
+         "Specification says create_info_count must be > 0.");
 
   auto result = next_proc(device, pipeline_cache, create_info_count,
                           create_infos, alloc_callbacks, pipelines);


### PR DESCRIPTION
Use `string_view` for logging and `absl::InlinedVector` for
pipeline stage hashes.

Log layer creation in constructors instead of using a global bool.