### PR TITLE
Record delay between shader module creation and first use

### DIFF
--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -165,12 +165,16 @@ void LayerData::LogEventOnly(std::string_view event_type,
   }
 }
 
+std::string LayerData::ShaderHashToString(uint64_t hash) {
+  return absl::StrFormat("%#x", hash);
+}
+
 std::string LayerData::PipelineHashToString(const HashVector& pipeline) const {
   return absl::StrCat("[",
                       absl::StrJoin(pipeline, ",",
-                                    [](std::string* out, uint64_t num) {
+                                    [](std::string* out, uint64_t hash) {
                                       return absl::StrAppend(
-                                          out, absl::StrFormat("%#x", num));
+                                          out, ShaderHashToString(hash));
                                     }),
                       "]");
 }

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -314,6 +314,9 @@ class LayerData {
   void LogEventOnly(std::string_view event_type,
                     std::string_view extra_content = "") const;
 
+  // Returns a string representation of |hash|.
+  static std::string ShaderHashToString(uint64_t hash);
+
   // Returns a string identifier of |pipeline|.
   std::string PipelineHashToString(const HashVector& pipeline) const;
 


### PR DESCRIPTION
... in pipeline creation.
    
The delay info is only logged to the even log.