### PR TITLE
Refine Vulkan header search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,15 +36,15 @@ if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
   endif()
   find_path(VulkanHeaders_INCLUDE_DIR
       NAMES vulkan/vk_layer.h
-      HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
-      NO_CMAKE_FIND_ROOT_PATH)
+      PATHS "${VULKAN_HEADERS_INSTALL_DIR}/include"
+      NO_DEFAULT_PATH)
   if(VulkanHeaders_INCLUDE_DIR MATCHES ".*_INCLUDE_DIR-NOTFOUND$")
     message(FATAL_ERROR "Vulkan Headers not found. Set VULKAN_HEADERS_INSTALL_DIR to the Vulkan-Headers installation directory.")
   endif()
 else()
   message(FATAL_ERROR "VULKAN_HEADERS_INSTALL_DIR must be specified!")
 endif()
-message(STATUS "VulkanHeaders ${VulkanHeaders_INCLUDE_DIR}")
+message(STATUS "VulkanHeaders: ${VulkanHeaders_INCLUDE_DIR}")
 
 if(DEFINED VULKAN_LOADER_GENERATED_DIR)
   if(NOT IS_ABSOLUTE "${VULKAN_LOADER_GENERATED_DIR}")
@@ -52,15 +52,15 @@ if(DEFINED VULKAN_LOADER_GENERATED_DIR)
   endif()
   find_path(VulkanLoaderGenerated_INCLUDE_DIR
       NAMES vk_layer_dispatch_table.h
-      HINTS ${VULKAN_LOADER_GENERATED_DIR}
-      NO_CMAKE_FIND_ROOT_PATH)
+      PATHS "${VULKAN_LOADER_GENERATED_DIR}"
+      NO_DEFAULT_PATH)
   if(VulkanLoaderGenerated_INCLUDE_DIR MATCHES ".*_INCLUDE_DIR-NOTFOUND$")
     message(FATAL_ERROR "Vulkan Loader sources not found. Set VULKAN_LOADER_GENERATED_DIR to the 'Vulkan-Loader/loader/generated' directory.")
   endif()
 else()
   message(FATAL_ERROR "VULKAN_LOADER_GENERATED_DIR must be specified!")
 endif()
-message(STATUS "VulkanLoaderGenerated ${VulkanLoaderGenerated_INCLUDE_DIR}")
+message(STATUS "VulkanLoaderGenerated: ${VulkanLoaderGenerated_INCLUDE_DIR}")
 
 # The library with the common code shared by all layers.
 add_library(performance_layers_support_lib INTERFACE)


### PR DESCRIPTION
Do not use default paths, consider only the user-specified directories.
This is based on
https://cmake.org/cmake/help/latest/command/find_path.html#:~:text=if%20no_default_path%20is%20specified.

Test: Install the `vulkan-headers` apt package and provide a wrong
absolute path. Make sure than an error is emitted.