### PR TITLE
Measure shader module creation times

### DIFF
--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -332,8 +332,9 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, CreateShaderModule,
                         const VkShaderModuleCreateInfo* create_info,
                         const VkAllocationCallbacks* allocator,
                         VkShaderModule* shader_module)) {
-  return GetLayerData()->CreateShaderModule(device, create_info, allocator,
-                                            shader_module);
+  return GetLayerData()
+      ->CreateShaderModule(device, create_info, allocator, shader_module)
+      .result;
 }
 
 // Override for vkDestroyDevice.  Removes the dispatch table for the device from


### PR DESCRIPTION
Make sure that the same time markers are used for both shader module
creation duration and shader use delay.