### PR TITLE
Fix device and instance destruction

### DIFF
--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -114,8 +114,8 @@ SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyInstance,
   CompileTimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextInstanceProcAddr(
       instance, &VkLayerInstanceDispatchTable::DestroyInstance);
-  next_proc(instance, allocator);
   layer_data->RemoveInstance(instance);
+  next_proc(instance, allocator);
 }
 
 // Override for vkCreateInstance.  Creates the dispatch table for this instance
@@ -250,8 +250,8 @@ SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyDevice,
   CompileTimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::DestroyDevice);
-  next_proc(device, allocator);
   layer_data->RemoveDevice(device);
+  next_proc(device, allocator);
 }
 
 // Override for vkCreateDevice.  Builds the dispatch table for the new device

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -192,8 +192,8 @@ SPL_FRAME_TIME_LAYER_FUNC(void, DestroyInstance,
   auto* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextInstanceProcAddr(
       instance, &VkLayerInstanceDispatchTable::DestroyInstance);
-  next_proc(instance, allocator);
   layer_data->RemoveInstance(instance);
+  next_proc(instance, allocator);
 }
 
 // Override for vkCreateInstance.  Creates the dispatch table for this instance
@@ -230,8 +230,8 @@ SPL_FRAME_TIME_LAYER_FUNC(void, DestroyDevice,
   auto* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::DestroyDevice);
-  next_proc(device, allocator);
   layer_data->RemoveDevice(device);
+  next_proc(device, allocator);
 }
 
 // Override for vkCreateDevice.  Builds the dispatch table for the new device

--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -133,8 +133,8 @@ SPL_MEMORY_USAGE_LAYER_FUNC(void, DestroyInstance,
   performancelayers::LayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextInstanceProcAddr(
       instance, &VkLayerInstanceDispatchTable::DestroyInstance);
-  next_proc(instance, allocator);
   layer_data->RemoveInstance(instance);
+  next_proc(instance, allocator);
 }
 
 // Override for vkCreateInstance.  Creates the dispatch table for this instance
@@ -175,8 +175,8 @@ SPL_MEMORY_USAGE_LAYER_FUNC(void, DestroyDevice,
 
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::DestroyDevice);
-  next_proc(device, allocator);
   layer_data->RemoveDevice(device);
+  next_proc(device, allocator);
 }
 
 // Override for vkQueuePresentKHR. Used to log memory usage once per frame.

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -57,8 +57,8 @@ SPL_RUNTIME_LAYER_FUNC(void, DestroyInstance,
   performancelayers::RuntimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextInstanceProcAddr(
       instance, &VkLayerInstanceDispatchTable::DestroyInstance);
-  next_proc(instance, allocator);
   layer_data->RemoveInstance(instance);
+  next_proc(instance, allocator);
 }
 
 // Override for vkCreateInstance.  Creates the dispatch table for this instance
@@ -345,8 +345,8 @@ SPL_RUNTIME_LAYER_FUNC(void, DestroyDevice,
   performancelayers::RuntimeLayerData* layer_data = GetLayerData();
   auto next_proc = layer_data->GetNextDeviceProcAddr(
       device, &VkLayerDispatchTable::DestroyDevice);
-  next_proc(device, allocator);
   layer_data->RemoveDevice(device);
+  next_proc(device, allocator);
 }
 
 // Override for vkCreateDevice.  Builds the dispatch table for the new device


### PR DESCRIPTION
Remove device/instance data before calling into the next procedure. This
is so that we do not use invalidated handles.

Make sure that implicit cache created by cache sideload layer are
destroyed before the matching device is destroyed, to conform with
```
VUID-vkDestroyDevice-device-00378
All child objects created on device must have been destroyed prior to destroying device
```