### PR TITLE
Update json manifest to support Vulkan 1.2 and 1.3

### DIFF
--- a/layer/VkLayer_stadia_frame_time.json
+++ b/layer/VkLayer_stadia_frame_time.json
@@ -5,7 +5,7 @@
     "name": "VK_LAYER_STADIA_frame_time",
     "type": "GLOBAL",
     "library_path": "libVkLayer_stadia_frame_time.so",
-    "api_version": "1.1.74",
+    "api_version": "1.3.216",
     "implementation_version": "1",
     "description": "Measures the time between calls to vkQueuePresentKHR.",
     "functions": {

--- a/layer/VkLayer_stadia_memory_usage.json
+++ b/layer/VkLayer_stadia_memory_usage.json
@@ -5,7 +5,7 @@
     "name": "VK_LAYER_STADIA_memory_usage",
     "type": "GLOBAL",
     "library_path": "libVkLayer_stadia_memory_usage.so",
-    "api_version": "1.1.74",
+    "api_version": "1.3.216",
     "implementation_version": "1",
     "description": "Measures the device memory usage of a Vulkan aplication.",
     "functions": {

--- a/layer/VkLayer_stadia_pipeline_cache_sideload.json
+++ b/layer/VkLayer_stadia_pipeline_cache_sideload.json
@@ -5,7 +5,7 @@
     "name": "VK_LAYER_STADIA_pipeline_cache_sideload",
     "type": "GLOBAL",
     "library_path": "libVkLayer_stadia_pipeline_cache_sideload.so",
-    "api_version": "1.1.74",
+    "api_version": "1.3.216",
     "implementation_version": "1",
     "description": "Sideloads Vulkan Pipeline Cache files.",
     "functions": {

--- a/layer/VkLayer_stadia_pipeline_compile_time.json
+++ b/layer/VkLayer_stadia_pipeline_compile_time.json
@@ -5,7 +5,7 @@
     "name": "VK_LAYER_STADIA_pipeline_compile_time",
     "type": "GLOBAL",
     "library_path": "libVkLayer_stadia_pipeline_compile_time.so",
-    "api_version": "1.1.74",
+    "api_version": "1.3.216",
     "implementation_version": "1",
     "description": "Measures the time it takes to compile pipelines.",
     "functions": {

--- a/layer/VkLayer_stadia_pipeline_runtime.json
+++ b/layer/VkLayer_stadia_pipeline_runtime.json
@@ -5,7 +5,7 @@
     "name": "VK_LAYER_STADIA_pipeline_runtime",
     "type": "GLOBAL",
     "library_path": "libVkLayer_stadia_pipeline_runtime.so",
-    "api_version": "1.1.74",
+    "api_version": "1.3.216",
     "implementation_version": "1",
     "description": "Measures the time it takes to run pipelines.",
     "functions": {


### PR DESCRIPTION
The `api_version` is effectively an upper bound on the supported Vulkan
version. Update to a recent version of Vulkan-Headers.
Tested manually with two 1.2 applications and a 1.2 ICD.