### PR TITLE
remove an unneeded import of a legacy header file

### DIFF
--- a/layer/input_buffer.cc
+++ b/layer/input_buffer.cc
@@ -23,7 +23,6 @@
 
 #if defined(__unix__)
 #include <fcntl.h>
-#include <sys/io.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
This file doesn't exist on newer platforms like aarch64.