### PR TITLE
Erase destroyed shader modules from LayerData. 

### DIFF
--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -242,7 +242,15 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateShaderModule,
   return res.result;
 }
 
-// Override for vkDestroyDevice.  Removes the dispatch table for the device from
+// Override for vkDestroyShaderModule. Erases the shader module from the layer
+// data.
+SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyShaderModule,
+                            (VkDevice device, VkShaderModule shader_module,
+                             const VkAllocationCallbacks* allocator)) {
+  return GetLayerData()->DestroyShaderModule(device, shader_module, allocator);
+}
+
+// Override for vkDestroyDevice. Removes the dispatch table for the device from
 // the layer data.
 SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyDevice,
                             (VkDevice device,
@@ -254,7 +262,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(void, DestroyDevice,
   next_proc(device, allocator);
 }
 
-// Override for vkCreateDevice.  Builds the dispatch table for the new device
+// Override for vkCreateDevice. Builds the dispatch table for the new device
 // and add it to the layer data.
 SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateDevice,
                             (VkPhysicalDevice physical_device,
@@ -270,6 +278,8 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateDevice,
     SPL_DISPATCH_DEVICE_FUNC(CreateComputePipelines);
     SPL_DISPATCH_DEVICE_FUNC(CreateGraphicsPipelines);
     SPL_DISPATCH_DEVICE_FUNC(CreateShaderModule);
+    SPL_DISPATCH_DEVICE_FUNC(DestroyShaderModule);
+
     return dispatch_table;
   };
 

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -269,4 +269,13 @@ LayerData::ShaderModuleCreateResult LayerData::CreateShaderModule(
       HashShader(*shader_module, create_info->pCode, create_info->codeSize);
   return {result, hash, start, end};
 }
+
+void LayerData::DestroyShaderModule(VkDevice device,
+                                    VkShaderModule shader_module,
+                                    const VkAllocationCallbacks* allocator) {
+  auto next_proc =
+      GetNextDeviceProcAddr(device, &VkLayerDispatchTable::DestroyShaderModule);
+  EraseShader(shader_module);
+  next_proc(device, shader_module, allocator);
+}
 }  // namespace performancelayers

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -240,6 +240,14 @@ class LayerData {
     return proc_addr;
   }
 
+  // Removes a previously created shader module from the LayerData. This is
+  // called while destroying the shader module.
+  void EraseShader(VkShaderModule shader_module) {
+    absl::MutexLock lock(&shader_hash_lock_);
+    assert(shader_hash_map_.contains(shader_module));
+    shader_hash_map_.erase(shader_module);
+  }
+
   // Records the hash of |code|, whose size is |size|, and associates it with
   // |shader_module|. This must be called before you can call |GetShaderHash|
   // with |shader_module|. Returns the calculated hash value.
@@ -352,6 +360,11 @@ class LayerData {
   ShaderModuleCreateResult CreateShaderModule(
       VkDevice device, const VkShaderModuleCreateInfo* create_info,
       const VkAllocationCallbacks* allocator, VkShaderModule* shader_module);
+
+  // Removes the shader module by calling |DestroyShaderModule| for the next
+  // layer. Also, removes the record of shader module from the LayerData.
+  void DestroyShaderModule(VkDevice device, VkShaderModule shader_module,
+                           const VkAllocationCallbacks* allocator);
 
  private:
   mutable absl::Mutex instance_dispatch_lock_;

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -337,6 +337,14 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, CreateShaderModule,
       .result;
 }
 
+// Override for vkDestroyShaderModule. Erases the shader module from
+// the layer data.
+SPL_RUNTIME_LAYER_FUNC(void, DestroyShaderModule,
+                       (VkDevice device, VkShaderModule shader_module,
+                        const VkAllocationCallbacks* allocator)) {
+  return GetLayerData()->DestroyShaderModule(device, shader_module, allocator);
+}
+
 // Override for vkDestroyDevice.  Removes the dispatch table for the device from
 // the layer data.
 SPL_RUNTIME_LAYER_FUNC(void, DestroyDevice,
@@ -366,6 +374,7 @@ SPL_RUNTIME_LAYER_FUNC(VkResult, CreateDevice,
     SPL_DISPATCH_DEVICE_FUNC(CreateComputePipelines);
     SPL_DISPATCH_DEVICE_FUNC(CreateGraphicsPipelines);
     SPL_DISPATCH_DEVICE_FUNC(CreateShaderModule);
+    SPL_DISPATCH_DEVICE_FUNC(DestroyShaderModule);
     SPL_DISPATCH_DEVICE_FUNC(CmdBindPipeline);
     SPL_DISPATCH_DEVICE_FUNC(CmdDispatch);
     SPL_DISPATCH_DEVICE_FUNC(CmdDraw);


### PR DESCRIPTION
Previously, when DestroyShaderModule was called, the module was removed
but its record remained in the LayerData. Since the hash function uses
the pointer and the size of the shader module to create a key, another
shader module that is allocated in the same address and has the same
size could potentially cause a bug. Because its corresponding key will
be the same as the key that already exist in the LayerData.

Remove a shader module from the LayerData when DestroyShaderModule is
called. This makes sure that we don't keep record of the destroyed
objects.

Add a hook on DestroyShaderModule function in the compile_time_layer and
runtime_layer.

Fixes: https://github.com/googlestadia/performance-layers/issues/51