### PR TITLE
Refactor check-layers.yml for better resource utilization.

### DIFF
--- a/.github/workflows/check-layers.yml
+++ b/.github/workflows/check-layers.yml
@@ -7,14 +7,20 @@ on:
 jobs:
   build:
     name: Check (${{ matrix.config }}, ${{ matrix.compiler }}, ${{ matrix.generator }})
-    runs-on: ${{ matrix.host-os }}
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        host-os:    ["ubuntu-latest"]
         config:     [Debug, Release]
-        compiler:   [clang, gcc]
-        generator:  ["Ninja", "Unix Makefiles"]
+        compiler:   [clang]
+        generator:  ["Ninja"]
+        include:
+        - config: Release
+          compiler: gcc
+          generator: "Ninja"
+        - config: Debug
+          compiler: gcc
+          generator: "Unix Makefiles"
     steps:
       - name: Checkout
         run: |


### PR DESCRIPTION
The current CI is checking for every combination of config, compiler, and generator. The checks contain redundancy without introducing more coverage. To reduce the redundant checks, only a subset of the combinations should be executed.

The building for both ninja and Makefiles is redundant, so we mainly build for ninja, but have a single check for Makefiles.

Keep both gcc and clang to exploit their different optimizations and diagnostic features, and keep the checks independent of compiler-specific behaviors. No need to compile with both debug and release flags for both compilers.

Set the default config, compiler, and generator in the job's matrix. The include filed expands the matrix by adding `Makefiles, gcc, Release` and `Ninja, gcc, Debug` configurations.