### PR TITLE
Run vkcube with performance layers enabled.

### DIFF
--- a/.github/workflows/check-layers.yml
+++ b/.github/workflows/check-layers.yml
@@ -7,14 +7,20 @@ on:
 jobs:
   build:
     name: Check (${{ matrix.config }}, ${{ matrix.compiler }}, ${{ matrix.generator }})
-    runs-on: ${{ matrix.host-os }}
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        host-os:    ["ubuntu-latest"]
         config:     [Debug, Release]
-        compiler:   [clang, gcc]
-        generator:  ["Ninja", "Unix Makefiles"]
+        compiler:   [clang]
+        generator:  ["Ninja"]
+        include:
+        - config: Release
+          compiler: gcc
+          generator: "Ninja"
+        - config: Debug
+          compiler: gcc
+          generator: "Unix Makefiles"
     steps:
       - name: Checkout
         run: |

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2020-2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,17 +31,28 @@ ARG GENERATOR
 RUN export DEBIAN_FRONTEND=noninteractive && export TZ=America/New_York \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends \
-      build-essential gcc g++ clang-11 ninja-build cmake binutils-gold \
-      libc++-11-dev libc++abi-11-dev \
-      python python-distutils-extra python3 python3-distutils \
-      git vim-tiny \
-      libglm-dev libxcb-dri3-0 libxcb-present0 libpciaccess0 \
-	    libpng-dev libxcb-keysyms1-dev libxcb-dri3-dev libx11-dev \
-      libmirclient-dev libwayland-dev libxrandr-dev libxcb-ewmh-dev \
+       build-essential pkg-config ninja-build \
+       gcc g++ binutils-gold \
+       llvm-11 clang-11 clang-tidy-12 libclang-common-11-dev lld-11 \
+       python python3 python3-distutils python3-pip \
+       libssl-dev libx11-dev libxcb1-dev x11proto-dri2-dev libxcb-dri3-dev \
+       libxcb-dri2-0-dev lib32z1-dev libxcb-present-dev libxcb-xinerama0 libxshmfence-dev libxrandr-dev \
+       libwayland-dev \
+       git curl wget openssh-client \
+       gpg gpg-agent \
+    && wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add - \
+    && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.216-bionic.list https://packages.lunarg.com/vulkan/1.3.216/lunarg-vulkan-1.3.216-bionic.list \
+    && apt-get update \
+    && apt-get install -yqq --no-install-recommends \
+    vulkan-sdk x11-xserver-utils libvulkan-dev libvulkan1 xvfb mesa-vulkan-drivers \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 10 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 10 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 10
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade cmake \
+    && for tool in clang clang++ llvm-cov llvm-profdata llvm-symbolizer lld ld.lld ; do \
+         update-alternatives --install /usr/bin/"$tool" "$tool" /usr/bin/"$tool"-11 10 ; \
+        done \
+    && update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 10 \
+    && update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 10
 
 COPY . /performance-layers
 
@@ -76,3 +87,12 @@ RUN  CXX_COMPILER="g++" \
     && cmake --build . --target check \
     && cmake --build . --target install
 
+# Enable perfomance layers and test with `vkcube`
+RUN export LD_LIBRARY_PATH=/performance-layers/build:$LD_LIBRARY_PATH \ 
+    && export VK_INSTANCE_LAYERS=VK_LAYER_STADIA_pipeline_compile_time \
+    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_runtime \
+    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_cache_sideload \
+    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_memory_usage \
+    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_frame_time \
+    && export VK_LAYER_PATH=/performance-layers/layer \
+    && xvfb-run vkcube --c 1000 && echo Done!


### PR DESCRIPTION
After the build was done, the layers were not tested on an actual Vulkan
application.
All the layers are now enabled by getting included in `VK_INSTANCE_LAYERS`. 
By running `vkcube` we check if an application crashes with layers enabled.
