### PR TITLE
Test if enabled layers are populating their log files.

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -23,6 +23,8 @@
 
 FROM ubuntu:20.04
 
+SHELL ["/bin/bash", "-c"]
+
 ARG CONFIG
 ARG COMPILER
 ARG GENERATOR
@@ -87,12 +89,6 @@ RUN  CXX_COMPILER="g++" \
     && cmake --build . --target check \
     && cmake --build . --target install
 
-# Enable perfomance layers and test with `vkcube`.
-RUN export LD_LIBRARY_PATH=/performance-layers/build:$LD_LIBRARY_PATH \
-    && export VK_INSTANCE_LAYERS=VK_LAYER_STADIA_pipeline_compile_time \
-    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_runtime \
-    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_cache_sideload \
-    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_memory_usage \
-    && export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_frame_time \
-    && export VK_LAYER_PATH=/performance-layers/layer \
-    && xvfb-run vkcube --c 100 && echo Done!
+# Enable and test the performance layers.
+WORKDIR /performance-layers/docker
+RUN ./test_performance_layers.sh /performance-layers/build

--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Enables the performance layers by setting the evironment variables.
+# Executes vkcube and makes sure it runs without fault when performance layers 
+# are enabled.
+# Tests if each layer writes to its corresponding output file. 
+
+set -euo pipefail
+
+# Create a temp output directory for log files. 
+readonly OUTPUT_DIR="$(mktemp -d)"
+readonly INSTALL_DIR="$1"
+readonly LAYER_DIR="${INSTALL_DIR}/run/layer"
+
+declare -a output_files
+output_files=("compile_time.csv" "run_time.csv" "memory_usage.csv" 
+              "frame_time.csv" "events.log")
+
+#######################################
+# Checks if the layers write data in their specified log files.
+# If data does not exist in the file, writes an error message to stdout and
+# exits.
+# Globals:
+#   OUTPUT_DIR
+# Arguments:
+#   layer's log file name
+#######################################
+check_layer_log() {
+  local file_name="$1"
+
+  if [[ $(wc -l <"${OUTPUT_DIR}"/"${file_name}") -lt 2 ]]; then
+    echo "Error: ${file_name} has not been populated properly." 
+    exit 1
+  fi
+}
+
+export LD_LIBRARY_PATH="${INSTALL_DIR}":"${LD_LIBRARY_PATH-}"
+export VK_INSTANCE_LAYERS=VK_LAYER_STADIA_pipeline_compile_time
+export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_runtime
+export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_frame_time
+export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_memory_usage
+export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_cache_sideload
+export VK_LAYER_PATH="${LAYER_DIR}"
+export VK_COMPILE_TIME_LOG="${OUTPUT_DIR}"/compile_time.csv
+export VK_RUNTIME_LOG="${OUTPUT_DIR}"/run_time.csv
+export VK_FRAME_TIME_LOG="${OUTPUT_DIR}"/frame_time.csv
+export VK_MEMORY_USAGE_LOG="${OUTPUT_DIR}"/memory_usage.csv
+export VK_PERFORMANCE_LAYERS_EVENT_LOG_FILE="${OUTPUT_DIR}"/events.log
+
+# Test if an application can run with performance layers enabled.
+xvfb-run vkcube --c 100
+echo "Run is finished successfully!"
+
+# Check if each enabled layer produced its log file.
+for file in "${output_files[@]}"; do
+  check_layer_log "${file}"
+done


### PR DESCRIPTION
Setting the environment variables and running an application does not necessarily guarantee that the layers are enabled. Because the program can still run even if the environment variables are set incorrectly. There are many ways that allow us to check whether the layers are enabled or not. 
We can run `vulkaninfo` and look at the `layers` subsection. We can also use `grep <name-of-the-layer>` to  check whether or not they exist in `vulkaninfo`.
Moreover, when a layer is enabled, it produces logs and stores them in its log file which can be specified by setting its corresponding environment variable. By inspecting these log files we can determine the execution of the layer.

Since, in the next steps, we'd like to make sure that the logs are consistent with each other (and the input arguments), we've decided to use the second approach (inspecting the log files). The log files contain a header row followed by the data row(s). Here, we only examine the generation of data rather than the content of data. Hence, we only need to make sure that the log files contain a data row (has at least two rows).