### PR TITLE
Add checks for the content of the compile time log.

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -35,7 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && export TZ=America/New_York \
     && apt-get install -yqq --no-install-recommends \
        build-essential pkg-config ninja-build \
        gcc g++ binutils-gold \
-       llvm-11 clang-11 clang-tidy-12 libclang-common-11-dev lld-11 \
+       llvm-11 clang-11 clang-tidy-12 libclang-common-11-dev lld-11 llvm-11-dev \
        python python3 python3-distutils python3-pip \
        libssl-dev libx11-dev libxcb1-dev x11proto-dri2-dev libxcb-dri3-dev \
        libxcb-dri2-0-dev lib32z1-dev libxcb-present-dev libxcb-xinerama0 libxshmfence-dev libxrandr-dev \
@@ -50,13 +50,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && export TZ=America/New_York \
     && rm -rf /var/lib/apt/lists/* \
     && python3 -m pip install --no-cache-dir --upgrade pip \
     && python3 -m pip install --no-cache-dir --upgrade cmake \
-    && for tool in clang clang++ llvm-cov llvm-profdata llvm-symbolizer lld ld.lld ; do \
+    && for tool in clang clang++ llvm-cov llvm-profdata llvm-symbolizer lld ld.lld FileCheck; do \
          update-alternatives --install /usr/bin/"$tool" "$tool" /usr/bin/"$tool"-11 10 ; \
         done \
     && update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 10 \
     && update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 10
-
-COPY . /performance-layers
 
 # Get all dependencies.
 WORKDIR /dependencies
@@ -70,6 +68,8 @@ RUN git clone https://github.com/KhronosGroup/Vulkan-Headers.git \
          -DCMAKE_INSTALL_PREFIX=run \
     && cmake --build . \
     && cmake --build . --target install
+
+COPY . /performance-layers
 
 # Build performance layers.
 WORKDIR /performance-layers/build
@@ -90,5 +90,5 @@ RUN  CXX_COMPILER="g++" \
     && cmake --build . --target install
 
 # Enable and test the performance layers.
-WORKDIR /performance-layers/docker
-RUN ./test_performance_layers.sh /performance-layers/build
+WORKDIR /performance-layers/
+RUN ./docker/test_performance_layers.sh /performance-layers/build

--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -55,3 +55,7 @@ echo "Run is finished successfully!"
 for file in "${output_files[@]}"; do
   check_layer_log "${file}"
 done
+
+# Check that log file's contents matches what is expected.
+FileCheck test/check_compile_time_log.txt --input-file \
+  "${OUTPUT_DIR}"/compile_time.csv 

--- a/test/check_compile_time_log.txt
+++ b/test/check_compile_time_log.txt
@@ -1,0 +1,4 @@
+; Checks the pattern of compile time log file. Makes sure the header
+; and the data rows' format are as expected.
+; CHECK-LABEL: Pipeline,Compile Time (ns)
+; CHECK-NEXT: "[{{0x[a-zA-Z0-9]+,0x[a-zA-Z0-9]+}}]",{{[0-9]+}}


### PR DESCRIPTION
Previously, to verify the layers are working on an application, we only checked whether the log files were populated or not. This does not necessarily guarantee that the logs contain the correct data. Since we know the pattern in which the data was generated, we can check the content of the log file and see if it is as expected. There are many tools  that allow us to perform the pattern matching (e.g, LLVM FileCheck, OutputCheck, etc). We can also write a python script that reads the log file and matches it against a given pattern.
We have selected FileCheck because it is well maintained and easy to use. Moreover, we don't need to write the code that reads the input files, stores the data, etc. 
FileCheck receives two files and uses one to verify the other. Here, the `check_compile_time_log.txt` contains the patterns we expect to see in the compile_time_log.csv. The patterns can be literal (line 3) or contain a regular expression (line 4). If the patterns don't match, FileCheck will exit with a non-zero value.