### PR TITLE
Add checks to the frame time log file content.

### DIFF
--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -68,3 +68,6 @@ FileCheck "${PROJECT_ROOT_DIR}/test/check_compile_time_log.txt" --input-file \
 
 FileCheck "${PROJECT_ROOT_DIR}/test/check_memory_usage_log.txt" --input-file \
   "${OUTPUT_DIR}"/memory_usage.csv
+
+FileCheck "${PROJECT_ROOT_DIR}/test/check_frame_time_log.txt" --input-file \
+  "${OUTPUT_DIR}"/frame_time.csv

--- a/test/check_frame_time_log.txt
+++ b/test/check_frame_time_log.txt
@@ -1,0 +1,5 @@
+; Checks the pattern of frame time log file. Makes sure the header
+; and the data rows' format, and the data rows count are as expected.
+; CHECK-LABEL: Frame Time (ns),Benchmark State
+; CHECK-COUNT-99: {{[0-9]+}},{{[0-9]+}}
+; CHECK-NOT: {{[0-9]+}},{{[0-9]+}}


### PR DESCRIPTION
### `check_frame_time_log.txt` checks the header and the data rows' format. It also checks the data rows' count using `CHECK-COUNT-<num>` and `CHECK-NOT` to make sure the number is exactly as expected.