### PR TITLE
Add checks to the event log file contents.

### DIFF
--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -71,3 +71,6 @@ FileCheck "${PROJECT_ROOT_DIR}/test/check_memory_usage_log.txt" --input-file \
 
 FileCheck "${PROJECT_ROOT_DIR}/test/check_frame_time_log.txt" --input-file \
   "${OUTPUT_DIR}"/frame_time.csv
+
+FileCheck "${PROJECT_ROOT_DIR}/test/check_event_log.txt" --input-file \
+  "${OUTPUT_DIR}"/events.log

--- a/test/check_event_log.txt
+++ b/test/check_event_log.txt
@@ -1,0 +1,18 @@
+; Checks the pattern of event log file. Makes sure the data rows
+; Corresponding to each layer have the correct format.
+; Checks the shader hashes across different rows and guarantees they are
+; consistent.
+; Counts the number of memory and frame time logs and check if they are
+; as expected.
+; CHECK-DAG:  compile_time_layer_init,{{[0-9]+}}
+; CHECK-DAG:  memory_usage_layer_init,{{[0-9]+}}
+; CHECK-DAG:  frame_time_layer_init,{{[0-9]+}}
+; CHECK:      create_shader_module_ns,{{[0-9]+}},[[SHADER1:0x[a-zA-Z0-9]+]],{{[0-9]+}}
+; CHECK-NEXT: create_shader_module_ns,{{[0-9]+}},[[SHADER2:0x[a-zA-Z0-9]+]],{{[0-9]+}}
+; CHECK:      shader_module_first_use_slack_ns,{{[0-9]+}},[[SHADER1]],{{[0-9]+}}
+; CHECK-NEXT: shader_module_first_use_slack_ns,{{[0-9]+}},[[SHADER2]],{{[0-9]+}}
+; CHECK:      create_graphics_pipelines,{{[0-9]+}},"[[[SHADER1]],[[SHADER2]]]",{{[0-9]+}}
+; CHECK-DAG:  memory_usage_present,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
+; CHECK-DAG:  frame_present,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
+; CHECK-DAG:  memory_usage_destroy_device,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
+; CHECK-DAG:  frame_time_layer_exit,{{[0-9]+}},application_exit


### PR DESCRIPTION
In addition to layer-specified log files, all the layers write their logs into a shared log file (called event log). Like other log files, this file can be specified by setting an environment variable (`VK_RUNTIME_LOG`).

`Check_event_log.txt` contains the patterns against which the event log is tested. It checks the format and count of rows. Also, it uses string substitution to make sure the hash values are consistent across different lines. `SHADER1` and `SHADER2` are variables that are set when the shader modules are created. They are used in the subsequent lines to verify that the logged hash values remain the same.

Since the layers can be executed in any order (based on their order in `VK_INSTANCE_LAYERS`) `CHECK-DAG` is used to look for the patterns regardless of their precedence. For instance, if `frame_time_layer_init` is moved before `compiler_time_layer_init`, the check will pass. The order of `CHECK-DAG`s does not matter until we have another type of check. For instance, the `CHECK` at line 10 acts as a barrier for the `CHECK-DAG`s before it.

To be less prone to the order of the frame time and memory usage layers, we check their logs in both orders; `memory usage` first then `frame time` and the reverse.`[[:space:]].*` is used to capture the new line between these two logs.