### PR TITLE
Implement Logger abstraction for logging Events.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ target_link_libraries(layer_support_tests PRIVATE
     performance_layers_support_lib
     gtest
     gtest_main
+    gmock
     ${FILESYSTEM_LIB_NAME}
 )
 


### PR DESCRIPTION
`EventLogger` takes `Event`s as input and produces logs based on a desired format. Each output format (such as CSV, ChromeTraceEvent, etc) implements the `EventLogger` and overrides the virtual methods based on its specifications.

`FilterLogger` receives an `EventLogger` and a `LogLevel` and filters the incoming events to the logger based on the given `LogLevel`.

`BroadcastLogger` is a logger that keeps multiple loggers. When a function is invoked, it invokes the function on all of its loggers. It allows us to register multiple loggers for a specific event. For instance, compile time logs can be in the compile_time private file and the event.log file. Hence, we register both loggers for the compile time events.

Issue: #81