### PR TITLE
Refactor logging.cc and logging.h to have more special names.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ target_sources(performance_layers_support_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/input_buffer.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_utils.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/layer/logging.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/debug_logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/log_scanner.cc
 )
 target_include_directories(performance_layers_support_lib INTERFACE

--- a/layer/cache_sideload_layer.cc
+++ b/layer/cache_sideload_layer.cc
@@ -19,10 +19,10 @@
 #include <string_view>
 
 #include "absl/container/flat_hash_map.h"
+#include "debug_logging.h"
 #include "input_buffer.h"
 #include "layer_data.h"
 #include "layer_utils.h"
-#include "logging.h"
 
 namespace performancelayers {
 namespace {

--- a/layer/debug_logging.cc
+++ b/layer/debug_logging.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "logging.h"
+#include "debug_logging.h"
 
 #include <cassert>
 #include <cstdio>

--- a/layer/debug_logging.h
+++ b/layer/debug_logging.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOGGING_H_
-#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOGGING_H_
+#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_DEBUG_LOGGING_H_
+#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_DEBUG_LOGGING_H_
 
 #include <sstream>
 
@@ -58,4 +58,4 @@ class MessageLogger {
   performancelayers::MessageLogger( \
       performancelayers::LogMessageKind::LOG_LEVEL_, __FILE__, __LINE__)
 
-#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOGGING_H_
+#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_DEBUG_LOGGING_H_

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -21,10 +21,10 @@
 #include <string>
 #include <type_traits>
 
+#include "debug_logging.h"
 #include "layer_data.h"
 #include "layer_utils.h"
 #include "log_scanner.h"
-#include "logging.h"
 
 namespace {
 // ----------------------------------------------------------------------------

--- a/layer/input_buffer.cc
+++ b/layer/input_buffer.cc
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "absl/strings/str_cat.h"
-#include "logging.h"
+#include "debug_logging.h"
 
 #if defined(__unix__)
 #include <fcntl.h>

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -21,8 +21,8 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
+#include "debug_logging.h"
 #include "layer_utils.h"
-#include "logging.h"
 
 namespace {
 

--- a/layer/log_scanner.cc
+++ b/layer/log_scanner.cc
@@ -18,7 +18,7 @@
 #include <cassert>
 
 #include "absl/strings/match.h"
-#include "logging.h"
+#include "debug_logging.h"
 
 namespace performancelayers {
 

--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "debug_logging.h"
 #include "layer_data.h"
 #include "layer_utils.h"
-#include "logging.h"
 
 namespace {
 // ----------------------------------------------------------------------------

--- a/layer/runtime_layer.cc
+++ b/layer/runtime_layer.cc
@@ -18,8 +18,8 @@
 #include <functional>
 #include <string>
 
+#include "debug_logging.h"
 #include "layer_utils.h"
-#include "logging.h"
 #include "runtime_layer_data.h"
 
 namespace {

--- a/layer/runtime_layer_data.cc
+++ b/layer/runtime_layer_data.cc
@@ -16,7 +16,7 @@
 
 #include <inttypes.h>
 
-#include "logging.h"
+#include "debug_logging.h"
 
 namespace performancelayers {
 

--- a/units/input_buffer_tests.cc
+++ b/units/input_buffer_tests.cc
@@ -18,9 +18,9 @@
 #include <numeric>
 #include <vector>
 
+#include "debug_logging.h"
 #include "gtest/gtest.h"
 #include "input_buffer.h"
-#include "logging.h"
 
 namespace {
 


### PR DESCRIPTION
The logging.cc and logging.h files contain functions used for the debug logs. That is why their name is changed to debug_logging.The `EventLogger` is also used for logging and will be added to this directory. Using specific file names that describe the functionality of each logger helps us differentiate them easily.