### PR TITLE
Add implementation for `CSVLogger`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,11 @@ message(STATUS "VulkanLoaderGenerated: ${VulkanLoaderGenerated_INCLUDE_DIR}")
 # The library with the common code shared by all layers.
 add_library(performance_layers_support_lib INTERFACE)
 target_sources(performance_layers_support_lib INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/csv_logging.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/debug_logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/input_buffer.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_utils.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/layer/debug_logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/log_scanner.cc
 )
 target_include_directories(performance_layers_support_lib INTERFACE
@@ -133,6 +134,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/layer
 
 enable_testing()
 add_executable(layer_support_tests
+    units/csv_log_tests.cc
     units/event_log_tests.cc
     units/input_buffer_tests.cc
     units/log_scanner_tests.cc

--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -1,0 +1,90 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "csv_logging.h"
+
+#include <sstream>
+
+#include "debug_logging.h"
+
+namespace {
+std::string ValueToCSVString(const std::string &value) { return value; }
+
+std::string ValueToCSVString(const int64_t value) {
+  return std::to_string(value);
+}
+
+std::string ValueToCSVString(const std::vector<int64_t> &values) {
+  std::ostringstream csv_string;
+  csv_string << "\"[";
+  size_t e = values.size();
+  for (size_t i = 0; i != e; ++i) {
+    const char *delimiter = i < e - 1 ? "," : "";
+    csv_string << values[i] << delimiter;
+  }
+  csv_string << "]\"";
+  return csv_string.str();
+}
+
+}  // namespace
+
+namespace performancelayers {
+// Takes an `Event` instance as an input and generates a csv string containing
+// `event`'s name and attribute values.
+// TODO(miladhakimi): Differentiate hashes and other integers. Hashes
+// should be displayed in hex.
+std::string EventToCSVString(Event &event) {
+  const std::vector<Attribute *> &attributes = event.GetAttributes();
+
+  std::ostringstream csv_str;
+  csv_str << event.GetEventName();
+  csv_str << ",";
+  for (size_t i = 0, e = attributes.size(); i != e; ++i) {
+    switch (attributes[i]->GetValueType()) {
+      case ValueType::kInt64: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<Int64Attr>()->GetValue());
+        break;
+      }
+      case ValueType::kString: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<StringAttr>()->GetValue());
+        break;
+      }
+      case ValueType::kVectorInt64: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<VectorInt64Attr>()->GetValue());
+        break;
+      }
+    }
+    if (i + 1 != e) csv_str << ",";
+  }
+  return csv_str.str();
+}
+
+CSVLogger::CSVLogger(const char *csv_header, const char *filename)
+    : header_(csv_header) {
+  if (filename) {
+    out_ = fopen(filename, "w");
+    if (!out_) {
+      SPL_LOG(ERROR) << "Failed to open " << filename
+                     << ". Using stderr as the alternative output.";
+      out_ = stderr;
+    }
+  } else {
+    out_ = stderr;
+  }
+}
+
+}  // namespace performancelayers

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -1,0 +1,85 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_CSV_LOGGING_H_
+#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_CSV_LOGGING_H_
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+#include "event_logging.h"
+#include "layer_data.h"
+
+namespace performancelayers {
+// Takes an `Event` instance as an input and generates a csv string containing
+// `event`'s name and attribute values.
+// TODO(miladhakimi): Differentiate hashes and other integers. Hashes
+// should be displayed in hex.
+std::string EventToCSVString(Event &event);
+
+// CSVLogger logs the events in the CSV format to the output given in its
+// constructor. Sample use:
+// ```c++
+// CSVLogger logger("pipeline,duration", "compile_time.csv");
+// logger.StartLog();
+// Event compile_time_event = ...;
+// logger.AddEvent(&compile_time_event);
+// logger.Flush();
+// logger.EndLog();
+// ```
+// There is no need to add '\n' at the end of the csv_header in the constructor.
+// This is handled by the implementation. `filename` can be nullptr. In this
+// case, the output will be written to stderr.
+// The only valid methods after calling `EndLog()` are `EndLog()` and the
+// deconstructor.
+class CSVLogger : public EventLogger {
+ public:
+  CSVLogger(const char *csv_header, const char *filename);
+
+  ~CSVLogger() {
+    if (out_ && out_ != stderr) fclose(out_);
+  }
+
+  void AddEvent(Event *event) override {
+    assert(out_);
+    std::string event_str = EventToCSVString(*event);
+    WriteLnAndFlush(out_, event_str);
+  }
+
+  // Writes the CSV header given in the constructor to the output.
+  void StartLog() override {
+    assert(out_);
+    WriteLnAndFlush(out_, header_);
+  }
+
+  void EndLog() override {
+    if (out_ && out_ != stderr) {
+      fclose(out_);
+      out_ = nullptr;
+    }
+  }
+
+  void Flush() override {
+    assert(out_);
+    fflush(out_);
+  }
+
+ private:
+  FILE *out_ = nullptr;
+  const char *header_ = nullptr;
+};
+
+}  // namespace performancelayers
+#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_CSV_LOGGING_H_

--- a/units/csv_log_tests.cc
+++ b/units/csv_log_tests.cc
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "csv_logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace performancelayers {
+namespace {
+// This is a simple test and only calls the methods to make sure the
+// logger doesn't crash.
+TEST(CSVLogger, MethodCheck) {
+  CSVLogger logger("name,timestamp,pipeline,duration", nullptr);
+  VectorInt64Attr hashes("hashes", {2, 3});
+  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
+                                              hashes, 4, LogLevel::kHigh);
+  logger.StartLog();
+  logger.AddEvent(&pipeline_event);
+  logger.Flush();
+  logger.EndLog();
+  // Checks double `EndLog` calls.
+  logger.EndLog();
+
+  SUCCEED();
+}
+
+}  // namespace
+}  // namespace performancelayers


### PR DESCRIPTION
Some events produced by the layers should be written in CSV. `CSVLogger` is an implementation of `EventLogger` that takes events and generates logs in CSV format. It receives the CSV header in its constructor and writes it to the output when `StartLog()` is called. On `AddEvent()`, it converts the incoming event to a CSV string(a line of text) and writes it to the output.
Issues: #81 , #69 