### PR TITLE
Add implementation for CommonLogger.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ message(STATUS "VulkanLoaderGenerated: ${VulkanLoaderGenerated_INCLUDE_DIR}")
 # The library with the common code shared by all layers.
 add_library(performance_layers_support_lib INTERFACE)
 target_sources(performance_layers_support_lib INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/common_logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/csv_logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/debug_logging.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/input_buffer.cc
@@ -134,6 +135,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/layer
 
 enable_testing()
 add_executable(layer_support_tests
+    units/common_log_tests.cc
     units/csv_log_tests.cc
     units/event_log_tests.cc
     units/input_buffer_tests.cc

--- a/layer/common_logging.cc
+++ b/layer/common_logging.cc
@@ -12,42 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "common_logging.h"
+
+#include <string>
+
 #include "csv_logging.h"
-
-#include <sstream>
-
 #include "debug_logging.h"
+#include "event_logging.h"
 
 namespace performancelayers {
-std::string ValueToCSVString(const std::string &value) { return value; }
-
-std::string ValueToCSVString(const int64_t value) {
-  return std::to_string(value);
-}
-
-std::string ValueToCSVString(const std::vector<int64_t> &values) {
-  std::ostringstream csv_string;
-  csv_string << "\"[";
-  size_t e = values.size();
-  for (size_t i = 0; i != e; ++i) {
-    const char *delimiter = i < e - 1 ? "," : "";
-    csv_string << values[i] << delimiter;
-  }
-  csv_string << "]\"";
-  return csv_string.str();
-}
-
-// Takes an `Event` instance as an input and generates a csv string containing
-// `event`'s name and attribute values.
-// TODO(miladhakimi): Differentiate hashes and other integers. Hashes
-// should be displayed in hex.
-std::string EventToCSVString(Event &event) {
+std::string EventToCommonLogStr(Event &event) {
   const std::vector<Attribute *> &attributes = event.GetAttributes();
 
   std::ostringstream csv_str;
   csv_str << event.GetEventName();
   csv_str << ",";
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
+    csv_str << attributes[i]->GetName() << ":";
     switch (attributes[i]->GetValueType()) {
       case ValueType::kInt64: {
         csv_str << ValueToCSVString(
@@ -70,8 +51,7 @@ std::string EventToCSVString(Event &event) {
   return csv_str.str();
 }
 
-CSVLogger::CSVLogger(const char *csv_header, const char *filename)
-    : header_(csv_header) {
+CommonLogger::CommonLogger(const char *filename) {
   if (filename) {
     out_ = fopen(filename, "w");
     if (!out_) {

--- a/layer/common_logging.h
+++ b/layer/common_logging.h
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+#include "event_logging.h"
+#include "layer_data.h"
+
+namespace performancelayers {
+// Converts `event` to a string with the common log format. The common log
+// format looks like this:
+// `event_name,attribute1_name:attribute1_value,attribute2_name:attribute2_value,...`
+std::string EventToCommonLogStr(Event &event);
+
+// CommonLogger logs the events in the common log.
+// `filename` can be nullptr. In this case, the output will be written to
+// stderr. The only valid methods after calling `EndLog()` is `EndLog()`.
+class CommonLogger : public EventLogger {
+ public:
+  CommonLogger(const char *filename);
+
+  void AddEvent(Event *event) override {
+    assert(out_);
+    std::string event_str = EventToCommonLogStr(*event);
+    WriteLnAndFlush(out_, event_str);
+  }
+
+  void StartLog() override {}
+
+  void EndLog() override {
+    if (out_ && out_ != stderr) {
+      fclose(out_);
+      out_ = nullptr;
+    }
+  }
+
+  void Flush() override {
+    assert(out_);
+    fflush(out_);
+  }
+
+ private:
+  FILE *out_ = nullptr;
+};
+
+}  // namespace performancelayers

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -23,6 +23,12 @@
 #include "layer_data.h"
 
 namespace performancelayers {
+std::string ValueToCSVString(const std::string &value);
+
+std::string ValueToCSVString(const int64_t value);
+
+std::string ValueToCSVString(const std::vector<int64_t> &values);
+
 // Takes an `Event` instance as an input and generates a csv string containing
 // `event`'s name and attribute values.
 // TODO(miladhakimi): Differentiate hashes and other integers. Hashes
@@ -30,27 +36,14 @@ namespace performancelayers {
 std::string EventToCSVString(Event &event);
 
 // CSVLogger logs the events in the CSV format to the output given in its
-// constructor. Sample use:
-// ```c++
-// CSVLogger logger("pipeline,duration", "compile_time.csv");
-// logger.StartLog();
-// Event compile_time_event = ...;
-// logger.AddEvent(&compile_time_event);
-// logger.Flush();
-// logger.EndLog();
-// ```
+// constructor.
 // There is no need to add '\n' at the end of the csv_header in the constructor.
 // This is handled by the implementation. `filename` can be nullptr. In this
 // case, the output will be written to stderr.
-// The only valid methods after calling `EndLog()` are `EndLog()` and the
-// deconstructor.
+// The only valid methods after calling `EndLog()` is `EndLog()`.
 class CSVLogger : public EventLogger {
  public:
   CSVLogger(const char *csv_header, const char *filename);
-
-  ~CSVLogger() {
-    if (out_ && out_ != stderr) fclose(out_);
-  }
 
   void AddEvent(Event *event) override {
     assert(out_);

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -178,6 +178,15 @@ class CreateGraphicsPipelinesEvent : public Event {
 // events in various formats (CSV, Chrome Trace Event, etc). The `EventLogger`'s
 // methods can be called from multiple threads at the same time. Hence, they are
 // expected to be internally synchronized.
+// Sample use:
+// ```c++
+// EventLogger *logger = ;
+// logger->StartLog();
+// Event compile_time_event = ...;
+// logger->AddEvent(&compile_time_event);
+// logger->Flush();
+// logger->EndLog();
+// ```
 class EventLogger {
  public:
   virtual ~EventLogger() = default;

--- a/units/common_log_tests.cc
+++ b/units/common_log_tests.cc
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common_logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace performancelayers {
+namespace {
+// This is a simple test and only calls the methods to make sure the
+// logger doesn't crash.
+TEST(CommonLogger, MethodCheck) {
+  CommonLogger logger(nullptr);
+  VectorInt64Attr hashes("hashes", {2, 3});
+  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
+                                              hashes, 4, LogLevel::kHigh);
+  logger.StartLog();
+  logger.AddEvent(&pipeline_event);
+  logger.Flush();
+  logger.EndLog();
+  // Checks double `EndLog` calls.
+  logger.EndLog();
+
+  SUCCEED();
+}
+
+}  // namespace
+}  // namespace performancelayers


### PR DESCRIPTION
`CommonLogger` is an `EventLogger` implementation that logs the events in the common log file.
`EventToCommonLogStr` converts an event into a string in the following format: 
`event_name,attr1_name:attr1_value,attr2_name:attr2_value,...`