### PR TITLE
Rafactor memory usage layer to use CSVLogger.

### DIFF
--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -94,16 +94,15 @@ using Int64Attr = AttributeImpl<int64_t, ValueType::kInt64>;
 // initialize their own set of attributes.
 class Event {
  public:
-  Event(const char *name, LogLevel log_level)
-      : name_(name), log_level_(log_level) {}
+  Event(const char *name, std::vector<Attribute *> attributes,
+        LogLevel log_level)
+      : name_(name), attributes_(attributes), log_level_(log_level) {}
 
   virtual ~Event() = default;
 
-  // Each implementation of an `Event` contains attribute(s) and
-  // overrides this function to return them.
-  virtual const std::vector<Attribute *> &GetAttributes() = 0;
+  const std::vector<Attribute *> &GetAttributes() { return attributes_; };
 
-  virtual size_t GetNumAttributes() const = 0;
+  size_t GetNumAttributes() const { return attributes_.size(); };
 
   const char *GetEventName() const { return name_; }
 
@@ -111,6 +110,7 @@ class Event {
 
  private:
   const char *name_;
+  std::vector<Attribute *> attributes_;
   LogLevel log_level_;
 };
 
@@ -129,23 +129,15 @@ class CreateShaderModuleEvent : public Event {
   CreateShaderModuleEvent(const char *name, int64_t timestamp,
                           int64_t hash_value, int64_t duration,
                           LogLevel log_level)
-      : Event(name, log_level),
-        timestamp_{"timestamp", timestamp},
+      : timestamp_{"timestamp", timestamp},
         hash_value_{"hash", hash_value},
         duration_{"duration", duration},
-        attributes_{&timestamp_, &hash_value_, &duration_} {}
-
-  const std::vector<Attribute *> &GetAttributes() override {
-    return attributes_;
-  }
-
-  size_t GetNumAttributes() const override { return attributes_.size(); }
+        Event(name, {&timestamp_, &hash_value_, &duration_}, log_level) {}
 
  private:
   Int64Attr timestamp_;
   Int64Attr hash_value_;
   Int64Attr duration_;
-  std::vector<Attribute *> attributes_;
 };
 
 class CreateGraphicsPipelinesEvent : public Event {
@@ -153,23 +145,15 @@ class CreateGraphicsPipelinesEvent : public Event {
   CreateGraphicsPipelinesEvent(const char *name, int64_t timestamp,
                                VectorInt64Attr &hash_values, int64_t duration,
                                LogLevel log_level)
-      : Event(name, log_level),
-        timestamp_{"timestamp", timestamp},
+      : timestamp_{"timestamp", timestamp},
         hash_values_(hash_values),
         duration_{"duration", duration},
-        attributes_{&timestamp_, &hash_values_, &duration_} {}
-
-  const std::vector<Attribute *> &GetAttributes() override {
-    return attributes_;
-  }
-
-  size_t GetNumAttributes() const override { return attributes_.size(); }
+        Event(name, {&timestamp_, &hash_values_, &duration_}, log_level) {}
 
  private:
   Int64Attr timestamp_;
   VectorInt64Attr hash_values_;
   Int64Attr duration_;
-  std::vector<Attribute *> attributes_;
 };
 
 // EventLogger base class

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -87,8 +87,17 @@ void WriteLnAndFlush(FILE* file, std::string_view content) {
   fflush(file);
 }
 
+LayerData::LayerData() {
+  if (const char* event_log_file = getenv(kEventLogFileEnvVar)) {
+    // The underlying log file can be written to by multiple layers from
+    // multiple threads. All contentens have to be written in whole lines(s)
+    // at a time to ensure there is no unintended interleaving within a single
+    // line.
+    event_log_ = fopen(event_log_file, "a");
+  }
+}
+
 LayerData::LayerData(char* log_filename, const char* header) {
-  out_ = nullptr;
   if (log_filename) {
     out_ = fopen(log_filename, "w");
     if (out_ == nullptr) {

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -141,10 +141,12 @@ class LayerData {
       absl::flat_hash_map<DeviceKey, VkLayerDispatchTable>;
   using HashVector = absl::InlinedVector<uint64_t, 3>;
 
+  LayerData();
+
   LayerData(char* log_filename, const char* header);
 
   virtual ~LayerData() {
-    if (out_ != stderr) {
+    if (out_ && out_ != stderr) {
       fclose(out_);
     }
   }
@@ -395,7 +397,7 @@ class LayerData {
       ABSL_GUARDED_BY(pipeline_hash_lock_);
 
   // A pointer to the log file to use.
-  FILE* out_;
+  FILE* out_ = nullptr;
   mutable absl::Mutex log_time_lock_;
   // The last time LogTimeDelta was called.
   absl::Time last_log_time_ ABSL_GUARDED_BY(log_time_lock_) =


### PR DESCRIPTION
Add `MemoryUsageEvent` to memory usage layer.

This PR implements the `MemoryUsageEvent` class. It is an event that contains the allocation information such as current and peak allocated bytes. The data should be logged to both private and the common files. `MemoryUsageEvent` is used in both `QueuePresentKHR()` and `DestroyDevice()` instead of the current `LogUsage()` call.

`MemoryUsageLayerData` allocates and deallocates The `CSVLogger`. The logger accepts events through the new `LogEvent` method. `LogEvent` takes a `MemoryUsageEvent` as input and logs it to the memory layer's log file.