### PR TITLE
Implement `LayerDataWithLogger` to add logger to `LayerData`.

### DIFF
--- a/layer/common_logging.h
+++ b/layer/common_logging.h
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "event_logging.h"
-#include "layer_data.h"
+#include "layer_utils.h"
 
 namespace performancelayers {
 // Converts `event` to a string with the common log format. The common log

--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -45,8 +45,6 @@ std::string EventToCSVString(Event &event) {
   const std::vector<Attribute *> &attributes = event.GetAttributes();
 
   std::ostringstream csv_str;
-  csv_str << event.GetEventName();
-  csv_str << ",";
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     switch (attributes[i]->GetValueType()) {
       case ValueType::kInt64: {

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -16,11 +16,10 @@
 #define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_CSV_LOGGING_H_
 
 #include <cassert>
-#include <cstdio>
 #include <string>
 
 #include "event_logging.h"
-#include "layer_data.h"
+#include "layer_utils.h"
 
 namespace performancelayers {
 std::string ValueToCSVString(const std::string &value);

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -81,12 +81,6 @@ VkLayerDeviceCreateInfo* FindDeviceCreateInfo(
 }  // namespace
 
 namespace performancelayers {
-void WriteLnAndFlush(FILE* file, std::string_view content) {
-  assert(file);
-  fprintf(file, "%.*s\n", static_cast<int>(content.size()), content.data());
-  fflush(file);
-}
-
 LayerData::LayerData() {
   if (const char* event_log_file = getenv(kEventLogFileEnvVar)) {
     // The underlying log file can be written to by multiple layers from

--- a/layer/layer_utils.cc
+++ b/layer/layer_utils.cc
@@ -17,6 +17,12 @@
 #include <cassert>
 
 namespace performancelayers {
+void WriteLnAndFlush(FILE* file, std::string_view content) {
+  assert(file);
+  fprintf(file, "%.*s\n", static_cast<int>(content.size()), content.data());
+  fflush(file);
+}
+
 FunctionInterceptor::FunctionInterceptor(
     InterceptedVulkanFunc intercepted_function) {
   FunctionNameToPtr& registered_functions = GetInterceptedFunctions();

--- a/layer/layer_utils.h
+++ b/layer/layer_utils.h
@@ -15,6 +15,9 @@
 #ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_
 #define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_
 
+#include <cstdio>
+#include <string>
+
 #include "absl/container/flat_hash_map.h"
 #include "vulkan/vulkan.h"
 #include "vulkan/vulkan_core.h"
@@ -50,6 +53,8 @@
       reinterpret_cast<PFN_vk##FUNC_NAME_>(gdpa(*device, "vk" #FUNC_NAME_))
 
 namespace performancelayers {
+// Writes |content| to |file| and flushes it.
+void WriteLnAndFlush(FILE* file, std::string_view content);
 
 // Represents a type-erased layer function pointer intercepting a known
 // Vulkan function. Should be constructed with the type safe |Create|


### PR DESCRIPTION
Currently, to have loggers in the memory layer, we add them to the MemoryUsageLayerData which extends the LayerData. To Add loggers in the same way to the other layers, we need to apply the same changes to them which leads to duplicate code. Since there are layers that don't need loggers, we don't add the loggers to the LayerData class.

LayerDataWithLogger extends the LayerData by adding a CSV logger. The layers that require a logger can use it instead of LayerData.

This PR also refactors the memory usage layer to use the new class.
