### PR TITLE
Refactor the code to use chrono time instead of absl.

### DIFF
--- a/layer/layer_utils.cc
+++ b/layer/layer_utils.cc
@@ -17,6 +17,18 @@
 #include <cassert>
 
 namespace performancelayers {
+TimestampClock::time_point GetTimestamp() { return TimestampClock::now(); }
+
+DurationClock::time_point Now() { return DurationClock::now(); }
+
+int64_t ToInt64Nanoseconds(DurationClock::duration duration) {
+  return std::chrono::nanoseconds(duration).count();
+}
+
+int64_t ToUnixNanos(TimestampClock::time_point time) {
+  return std::chrono::nanoseconds(time.time_since_epoch()).count();
+}
+
 void WriteLnAndFlush(FILE* file, std::string_view content) {
   assert(file);
   fprintf(file, "%.*s\n", static_cast<int>(content.size()), content.data());

--- a/layer/layer_utils.h
+++ b/layer/layer_utils.h
@@ -15,6 +15,8 @@
 #ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_
 #define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_UTILS_H_
 
+#include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 
@@ -53,6 +55,30 @@
       reinterpret_cast<PFN_vk##FUNC_NAME_>(gdpa(*device, "vk" #FUNC_NAME_))
 
 namespace performancelayers {
+// steady_clock, system_clock, and high_resolution_clock comparison:
+// 1. steady_clock: A monotonic clock. The current value of steady_clock does
+// not matter, but the guarantee that is strictly increasing is useful for
+// calculating the difference between two samples.
+// 2. system_clock: Is the wall-clock. Used for time/day related stuff.
+// 3. high_resolution_clock: An alias for one of the above.
+using TimestampClock = std::chrono::system_clock;
+using DurationClock = std::chrono::steady_clock;
+
+// Returns a system_clock::time_point as the timestamp. The system_clock acts
+// like a real clock and shows the current time, while the steady_clock is a
+// monotonic clock and behaves like a chronometer. This is why system_clock is
+// used for the timestamp.
+TimestampClock::time_point GetTimestamp();
+
+// Returns a monotonic time_point to be used for measuring duration.
+DurationClock::time_point Now();
+
+// Converts a chrono duration to int64 nanoseconds.
+int64_t ToInt64Nanoseconds(DurationClock::duration duration);
+
+// Converts a chrono time_point to a Unix int64 nanoseconds representation.
+int64_t ToUnixNanos(TimestampClock::time_point time);
+
 // Writes |content| to |file| and flushes it.
 void WriteLnAndFlush(FILE* file, std::string_view content);
 


### PR DESCRIPTION
One of the future directions of perfomancelayers is to have dynamic
unloading to provide better support for the applications. Currently, the
`absl` libraries we're using don't support dynamic unloading. Hence, we
should not use `absl` in the new features and refactor the current
codebase to use alternative libraries.

This PR refactors the performancelayers to use `chrono` time instead of
`absl` time.

`chrono::steady_clock`, `chrono::system_clock`,
`chrono::high_resolution_clock`, and `absl::Now()` brief explanation:
1. `steady_clock`: A monotonic clock. The current value of steady_clock
does not matter, but the guarantee that is strictly increasing is useful
for calculating the difference between two samples.
2. `system_clock`: Is the wall-clock. Used for time/day related stuff.
3. `high_resolution_clock`: An alias for one of the above.
4. `absl::Now()`: Constructs an absl::Time from the system clock.

Previously, `absl::Now()` was used for the timestamp and measuring
duration. This PR separates these two by using `system_clock::now()` for
the timestamp and `steady_clock::now()` for the duration.