### PR TITLE
Refactor frame time layer to use `CSVLogger`.

### DIFF
--- a/layer/common_logging.cc
+++ b/layer/common_logging.cc
@@ -30,6 +30,11 @@ std::string EventToCommonLogStr(Event &event) {
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     csv_str << attributes[i]->GetName() << ":";
     switch (attributes[i]->GetValueType()) {
+      case ValueType::kBool: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<BoolAttr>()->GetValue());
+        break;
+      }
       case ValueType::kInt64: {
         csv_str << ValueToCSVString(
             attributes[i]->cast<Int64Attr>()->GetValue());

--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -15,10 +15,14 @@
 #include "csv_logging.h"
 
 #include <sstream>
+#include <string>
 
 #include "debug_logging.h"
+#include "event_logging.h"
 
 namespace performancelayers {
+std::string ValueToCSVString(const bool value) { return std::to_string(value); }
+
 std::string ValueToCSVString(const std::string &value) { return value; }
 
 std::string ValueToCSVString(const int64_t value) {
@@ -47,6 +51,11 @@ std::string EventToCSVString(Event &event) {
   std::ostringstream csv_str;
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     switch (attributes[i]->GetValueType()) {
+      case ValueType::kBool: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<BoolAttr>()->GetValue());
+        break;
+      }
       case ValueType::kInt64: {
         csv_str << ValueToCSVString(
             attributes[i]->cast<Int64Attr>()->GetValue());

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -20,7 +20,7 @@
 
 namespace performancelayers {
 // Set of supported value types for an attribute.
-enum ValueType { kString, kInt64, kVectorInt64 };
+enum ValueType { kString, kInt64, kVectorInt64, kBool };
 
 // Specifies the importance of an Eventk. Events are logged based on their level
 // of importance. E.g., compile_time.csv only containsk the important compile
@@ -88,6 +88,7 @@ using VectorInt64Attr =
     AttributeImpl<std::vector<int64_t>, ValueType::kVectorInt64>;
 using StringAttr = AttributeImpl<std::string, ValueType::kString>;
 using Int64Attr = AttributeImpl<int64_t, ValueType::kInt64>;
+using BoolAttr = AttributeImpl<bool, ValueType::kBool>;
 
 // Event represents the base struct for a loggable event. It contains the
 // event's name and the level of importance. The derived structs must define and

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -145,15 +145,18 @@ void LayerData::Log(std::string_view event_type, const HashVector& pipeline,
   LogLine(event_type, pipeline_and_content);
 }
 
-void LayerData::LogTimeDelta(std::string_view event_type,
-                             std::string_view extra_content) {
+int64_t LayerData::GetTimeDelta() {
   absl::MutexLock lock(&log_time_lock_);
   DurationClock::time_point now = Now();
+  int64_t logged_delta = -1;
+
   if (last_log_time_ != DurationClock::time_point::min()) {
-    int64_t logged_delta = ToInt64Nanoseconds(now - last_log_time_);
-    LogLine(event_type, CsvCat(logged_delta, extra_content));
+    // Using initialized logged_delta
+    logged_delta = ToInt64Nanoseconds(now - last_log_time_);
   }
+
   last_log_time_ = now;
+  return logged_delta;
 }
 
 void LayerData::LogEventOnly(std::string_view event_type,

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -319,9 +319,19 @@ class LayerData {
   void Log(std::string_view event_type, const HashVector& pipeline,
            std::string_view prefix) const;
 
-  // Logs the time since the last call to LogTimeDelta.
-  void LogTimeDelta(std::string_view event_type,
-                    std::string_view extra_content = "");
+  // Returns the time difference between the last time this method was called
+  // and now. The first call is used for initialization and does not calculate
+  // the time delta. It returns -1 indicating an invalid time delta. Use case
+  // example:
+  // ```c++
+  // int64_t time_delta = GetTimeDelta();
+  // if (time_delta != -1) {
+  //    std::cout << "Success: time_delta is " << time_delta << std::endl;
+  // } else {
+  //    std::cerr << "Error: time_delta is invalid." << std::endl;
+  // }
+  // ```
+  int64_t GetTimeDelta();
 
   // Logs an arbitrary |extra_content| to the event log file.
   // Doesn't write to the layer log file.


### PR DESCRIPTION
This PR adds support for bool type attributes and implements the FrameTimeEvent.

One side effect of this refactor is that it increases the performance of the frame time layer by reducing the critical section of the multi-threaded region. This is achieved by writing the log after updating the shared variable, last_time_log_.
last_time_log_ is a shared variable protected by a mutex. Previously, the LogTimeDelta() acquired the mutex, computed the time delta, logged an event based on time delta, and updated the last_time_log_. However, updating last_time_log_ could be done right after computing time delta without having to wait for the event to be written to the output.

GetTimeDelta() is a new function responsible for computing the time delta and updating the last_time_log_. The layer uses the time delta returned by this function and creates the log based on that outside of the critical section.
