### PR TITLE
Refactor compile time layer to use `CSVLogger`.

### DIFF
--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -36,7 +36,7 @@ std::string ValueToCSVString(const std::vector<int64_t> &values) {
   size_t e = values.size();
   for (size_t i = 0; i != e; ++i) {
     const char *delimiter = i < e - 1 ? "," : "";
-    csv_string << values[i] << delimiter;
+    csv_string << "0x" << std::hex << values[i] << delimiter;
   }
   csv_string << "]\"";
   return csv_string.str();

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -16,6 +16,7 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <iomanip>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_cat.h"
@@ -27,12 +28,6 @@
 namespace performancelayers {
 namespace {
 constexpr char kEventLogFileEnvVar[] = "VK_PERFORMANCE_LAYERS_EVENT_LOG_FILE";
-
-// Returns a quoted string.
-template <typename StrTy>
-std::string QuoteStr(StrTy&& str) {
-  return absl::StrCat("\"", std::forward<StrTy>(str), "\"");
-}
 
 // Returns event log file row prefix with ','-separated |event_type| and
 // |timestamp|.
@@ -130,18 +125,11 @@ void LayerData::LogLine(std::string_view event_type, std::string_view line,
 }
 
 void LayerData::Log(std::string_view event_type, const HashVector& pipeline,
-                    uint64_t time) const {
-  // Quote the comma-separated hash value array to always create 2 CSV cells.
-  std::string pipeline_hash = QuoteStr(PipelineHashToString(pipeline));
-  std::string pipeline_and_time = CsvCat(pipeline_hash, time);
-  LogLine(event_type, pipeline_and_time);
-}
-
-void LayerData::Log(std::string_view event_type, const HashVector& pipeline,
                     std::string_view prefix) const {
   // Quote the comma-separated hash value array to always create 2 CSV cells.
-  std::string pipeline_hash = QuoteStr(PipelineHashToString(pipeline));
-  std::string pipeline_and_content = CsvCat(pipeline_hash, prefix);
+  std::stringstream pipeline_hash_str;
+  pipeline_hash_str << std::quoted(PipelineHashToString(pipeline));
+  std::string pipeline_and_content = CsvCat(pipeline_hash_str.str(), prefix);
   LogLine(event_type, pipeline_and_content);
 }
 

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -308,14 +308,10 @@ class LayerData {
   void LogLine(std::string_view event_type, std::string_view line,
                TimestampClock::time_point timestamp = GetTimestamp()) const;
 
-  // Logs the compile time |time| for |pipeline| to the log file.
+  // Logs an arbitrary string prefixed by the given pipeline.
   // |event_type| is used as the key in the event log file, if enabled.
   // |pipeline| is any series of integers that represent the pipeline.
   // We are using the hash of each shader that is part of the pipeline.
-  void Log(std::string_view event_type, const HashVector& pipeline,
-           uint64_t time) const;
-
-  // Logs an arbitrary string prefixed by the given pipeline.
   void Log(std::string_view event_type, const HashVector& pipeline,
            std::string_view prefix) const;
 


### PR DESCRIPTION
This PR implements `CompileTimeEvent` which is an event that holds hash values and pipeline creation duration. This event is used by `CreateComputePipelines()` and `CreateGraphicsPipelines()` functions.