### PR TITLE
Fix reorder constructor warning/error.

### DIFF
--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -95,9 +95,8 @@ using BoolAttr = AttributeImpl<bool, ValueType::kBool>;
 // initialize their own set of attributes.
 class Event {
  public:
-  Event(const char *name, std::vector<Attribute *> attributes,
-        LogLevel log_level)
-      : name_(name), attributes_(attributes), log_level_(log_level) {}
+  Event(const char *name, LogLevel log_level)
+      : name_(name), log_level_(log_level) {}
 
   virtual ~Event() = default;
 
@@ -109,10 +108,15 @@ class Event {
 
   LogLevel GetLogLevel() const { return log_level_; }
 
+ protected:
+  void InitAttributes(std::initializer_list<Attribute *> attrs) {
+    attributes_ = {attrs.begin(), attrs.end()};
+  }
+
  private:
   const char *name_;
-  std::vector<Attribute *> attributes_;
   LogLevel log_level_;
+  std::vector<Attribute *> attributes_;
 };
 
 // An `Event` for the CreateShaderModule function.
@@ -130,10 +134,12 @@ class CreateShaderModuleEvent : public Event {
   CreateShaderModuleEvent(const char *name, int64_t timestamp,
                           int64_t hash_value, int64_t duration,
                           LogLevel log_level)
-      : timestamp_{"timestamp", timestamp},
+      : Event(name, log_level),
+        timestamp_{"timestamp", timestamp},
         hash_value_{"hash", hash_value},
-        duration_{"duration", duration},
-        Event(name, {&timestamp_, &hash_value_, &duration_}, log_level) {}
+        duration_{"duration", duration} {
+    InitAttributes({&timestamp_, &duration_, &hash_value_});
+  }
 
  private:
   Int64Attr timestamp_;
@@ -146,10 +152,12 @@ class CreateGraphicsPipelinesEvent : public Event {
   CreateGraphicsPipelinesEvent(const char *name, int64_t timestamp,
                                VectorInt64Attr &hash_values, int64_t duration,
                                LogLevel log_level)
-      : timestamp_{"timestamp", timestamp},
+      : Event(name, log_level),
+        timestamp_{"timestamp", timestamp},
         hash_values_(hash_values),
-        duration_{"duration", duration},
-        Event(name, {&timestamp_, &hash_values_, &duration_}, log_level) {}
+        duration_{"duration", duration} {
+    InitAttributes({&timestamp_, &hash_values_, &duration_});
+  }
 
  private:
   Int64Attr timestamp_;

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -52,13 +52,15 @@ const char* StrOrEmpty(const char* str_or_null) {
 class FrameTimeEvent : public Event {
  public:
   FrameTimeEvent(const char* name, int64_t time_delta, bool started)
-      : time_delta_("frame_time", time_delta),
-        started_("started", started),
-        Event(name, {&time_delta_, &started_}, LogLevel::kHigh) {}
+      : Event(name, LogLevel::kHigh),
+        time_delta_("frame_time", time_delta),
+        started_("started", started) {
+    InitAttributes({&time_delta_, &started_});
+  }
 
  private:
-  BoolAttr started_;
   Int64Attr time_delta_;
+  BoolAttr started_;
 };
 
 class FrameTimeLayerData : public LayerDataWithEventLogger {

--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -41,7 +41,9 @@ class MemoryUsageEvent : public Event {
   MemoryUsageEvent(const char* name, int64_t current, int64_t peak)
       : current_({"current", current}),
         peak_({"peak", peak}),
-        Event(name, {&current_, &peak_}, LogLevel::kHigh) {}
+        Event(name, LogLevel::kHigh) {
+    InitAttributes({&current_, &peak_});
+  }
 
  private:
   Int64Attr current_;


### PR DESCRIPTION
The constructor of the base class is always called before the
constructor of the subclass. This is true even if we call it at the end
of the constructor initializer list of the subclass.

We want to initialize `Event`'s `attributes_` with pointers coming from
the subclass upon construction. The subclasses contain different
attributes, create `vector<Attribute*>` in their constructor and
pass it to the `Event` constructor. Since we were passing pointers, the
program was still correct even if pointers were initialized after being
passed to the base constructor. The error says we must move the
call to the `Event` constructor to the beginning of the initializer
list. Despite being correct, initializing the variables after
passing them to the `Event` might look confusing. This is why we defined
a protected method, `InitAttributes()`, that takes the attribute
pointers and builds the `vector<Attribute*>` in the base class.