### PR TITLE
Add support for duration attribute.

### DIFF
--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -19,6 +19,7 @@
 
 #include "debug_logging.h"
 #include "event_logging.h"
+#include "layer_utils.h"
 
 namespace performancelayers {
 std::string ValueToCSVString(const bool value) { return std::to_string(value); }
@@ -41,6 +42,10 @@ std::string ValueToCSVString(const std::vector<int64_t> &values) {
   return csv_string.str();
 }
 
+std::string ValueToCSVString(DurationClock::duration value) {
+  return std::to_string(ToInt64Nanoseconds(value));
+}
+
 // Takes an `Event` instance as an input and generates a csv string containing
 // `event`'s name and attribute values.
 // TODO(miladhakimi): Differentiate hashes and other integers. Hashes
@@ -51,6 +56,11 @@ std::string EventToCSVString(Event &event) {
   std::ostringstream csv_str;
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     switch (attributes[i]->GetValueType()) {
+      case ValueType::kDuration: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<DurationAttr>()->GetValue());
+        break;
+      }
       case ValueType::kBool: {
         csv_str << ValueToCSVString(
             attributes[i]->cast<BoolAttr>()->GetValue());

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -28,8 +28,12 @@ std::string ValueToCSVString(const int64_t value);
 
 std::string ValueToCSVString(const std::vector<int64_t> &values);
 
+// Converts a `DurationClock::duration` to its nanoseconds representation.
+std::string ValueToCSVString(DurationClock::duration value);
+
 // Takes an `Event` instance as an input and generates a csv string containing
-// `event`'s name and attribute values.
+// `event`'s name and attribute values. The duration values will be logged in
+// nanoseconds.
 // TODO(miladhakimi): Differentiate hashes and other integers. Hashes
 // should be displayed in hex.
 std::string EventToCSVString(Event &event);

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -145,14 +145,14 @@ void LayerData::Log(std::string_view event_type, const HashVector& pipeline,
   LogLine(event_type, pipeline_and_content);
 }
 
-int64_t LayerData::GetTimeDelta() {
+DurationClock::duration LayerData::GetTimeDelta() {
   absl::MutexLock lock(&log_time_lock_);
   DurationClock::time_point now = Now();
-  int64_t logged_delta = -1;
+  DurationClock::duration logged_delta = DurationClock::duration::min();
 
   if (last_log_time_ != DurationClock::time_point::min()) {
     // Using initialized logged_delta
-    logged_delta = ToInt64Nanoseconds(now - last_log_time_);
+    logged_delta = now - last_log_time_;
   }
 
   last_log_time_ = now;

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -321,17 +321,18 @@ class LayerData {
 
   // Returns the time difference between the last time this method was called
   // and now. The first call is used for initialization and does not calculate
-  // the time delta. It returns -1 indicating an invalid time delta. Use case
-  // example:
+  // the time delta. It returns DurationClock::duration::min() indicating an
+  // invalid time delta. Use case example:
   // ```c++
-  // int64_t time_delta = GetTimeDelta();
-  // if (time_delta != -1) {
-  //    std::cout << "Success: time_delta is " << time_delta << std::endl;
+  // DurationClock::duration time_delta = GetTimeDelta();
+  // if (time_delta != DurationClock::duration::min()) {
+  //    std::cout << "Success: time_delta is " << ToInt64Nanoseconds(time_delta)
+  //    << std::endl;
   // } else {
   //    std::cerr << "Error: time_delta is invalid." << std::endl;
   // }
   // ```
-  int64_t GetTimeDelta();
+  DurationClock::duration GetTimeDelta();
 
   // Logs an arbitrary |extra_content| to the event log file.
   // Doesn't write to the layer log file.

--- a/units/common_log_tests.cc
+++ b/units/common_log_tests.cc
@@ -23,8 +23,9 @@ namespace {
 TEST(CommonLogger, MethodCheck) {
   CommonLogger logger(nullptr);
   VectorInt64Attr hashes("hashes", {2, 3});
-  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
-                                              hashes, 4, LogLevel::kHigh);
+  CreateGraphicsPipelinesEvent pipeline_event(
+      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
+      LogLevel::kHigh);
   logger.StartLog();
   logger.AddEvent(&pipeline_event);
   logger.Flush();

--- a/units/csv_log_tests.cc
+++ b/units/csv_log_tests.cc
@@ -23,8 +23,9 @@ namespace {
 TEST(CSVLogger, MethodCheck) {
   CSVLogger logger("name,timestamp,pipeline,duration", nullptr);
   VectorInt64Attr hashes("hashes", {2, 3});
+  DurationClock::duration dur;
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
-                                              hashes, 4, LogLevel::kHigh);
+                                              hashes, dur, LogLevel::kHigh);
   logger.StartLog();
   logger.AddEvent(&pipeline_event);
   logger.Flush();

--- a/units/event_log_tests.cc
+++ b/units/event_log_tests.cc
@@ -71,7 +71,7 @@ TEST(Event, AttributeCreation) {
 TEST(Event, CreateShaderModuleEventCreation) {
   const int64_t timestamp_val = 1601314732230797664;
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
-  const int64_t duration = 926318;
+  DurationClock::duration duration(1);
   CreateShaderModuleEvent compile_event("compile_time", timestamp_val,
                                         hash_val1, duration, LogLevel::kLow);
   EXPECT_EQ(compile_event.GetNumAttributes(), 3);
@@ -80,7 +80,7 @@ TEST(Event, CreateShaderModuleEventCreation) {
 TEST(Event, ShaderModuleEventCreation) {
   const int64_t timestamp_val = 1601314732230797664;
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
-  const int64_t duration = 926318;
+  DurationClock::duration duration(926318);
   CreateShaderModuleEvent compile_event("compile_time", timestamp_val,
                                         hash_val1, duration, LogLevel::kLow);
   ASSERT_EQ(compile_event.GetNumAttributes(), 3);
@@ -90,7 +90,7 @@ TEST(Event, GraphicsPipelinesEventCreation) {
   const int64_t timestamp_val = 1601314732230797664;
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
-  const int64_t duration = 926318;
+  DurationClock::duration duration(926318);
 
   VectorInt64Attr hashes("hashes", {hash_val1, hash_val2});
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
@@ -103,7 +103,7 @@ TEST(Event, CreateGraphicsPipelinesEventCreation) {
   const int64_t timestamp_val = 1601314732230797664;
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
-  const int64_t duration = 926318;
+  DurationClock::duration duration(926318);
   VectorInt64Attr hashes("hashes", {hash_val1, hash_val2});
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
                                               timestamp_val, hashes, duration,
@@ -121,10 +121,11 @@ TEST(EventLogger, TestLoggerCreation) {
 
 TEST(EventLogger, TestLoggerFunctionCalls) {
   VectorInt64Attr hashes("hashes", {2, 3});
-  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
-                                              hashes, 4, LogLevel::kHigh);
-  CreateShaderModuleEvent compile_event("compile_time", 1, 2, 3,
-                                        LogLevel::kLow);
+  CreateGraphicsPipelinesEvent pipeline_event(
+      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
+      LogLevel::kHigh);
+  CreateShaderModuleEvent compile_event(
+      "compile_time", 1, 2, DurationClock::duration(3), LogLevel::kLow);
   TestLogger test_logger;
 
   test_logger.AddEvent(&pipeline_event);
@@ -144,10 +145,11 @@ TEST(EventLogger, TestLoggerFunctionCalls) {
 
 TEST(EventLogger, FilterLoggerInsert) {
   VectorInt64Attr hashes("hashes", {2, 3});
-  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
-                                              hashes, 4, LogLevel::kHigh);
-  CreateShaderModuleEvent compile_event("compile_time", 1, 2, 3,
-                                        LogLevel::kLow);
+  CreateGraphicsPipelinesEvent pipeline_event(
+      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
+      LogLevel::kHigh);
+  CreateShaderModuleEvent compile_event(
+      "compile_time", 1, 2, DurationClock::duration(3), LogLevel::kLow);
   TestLogger test_logger;
   FilterLogger filter(&test_logger, LogLevel::kHigh);
   filter.AddEvent(&pipeline_event);
@@ -166,10 +168,11 @@ TEST(EventLogger, BroadcastLoggerCreation) {
 
 TEST(EventLogger, BroadcastLoggerFunctionCalls) {
   VectorInt64Attr hashes("hashes", {2, 3});
-  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
-                                              hashes, 4, LogLevel::kHigh);
-  CreateShaderModuleEvent compile_event("compile_time", 1, 2, 3,
-                                        LogLevel::kLow);
+  CreateGraphicsPipelinesEvent pipeline_event(
+      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
+      LogLevel::kHigh);
+  CreateShaderModuleEvent compile_event(
+      "compile_time", 1, 2, DurationClock::duration(3), LogLevel::kLow);
   TestLogger test_logger1, test_logger2, test_logger3;
   FilterLogger filter(&test_logger1, LogLevel::kHigh);
   BroadcastLogger broadcast1({&filter, &test_logger2});


### PR DESCRIPTION
By using an `Int64Attr` as a single number that represents time-related values (duration/timestamp), we would loose the time unit information.

The `DurationAttr` is the base class for attributes that contain duration information. It is a wrapper around a `chrono::steady_clock::duration` variable. Each subclass implements the `DurationAttr` based on a time unit and converts the duration variable into an `int` to represent it in that unit.