### PR TITLE
Fix reorder constructor warning/error.

### DIFF
--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -39,9 +39,9 @@ constexpr char kLogFilenameEnvVar[] = "VK_MEMORY_USAGE_LOG";
 class MemoryUsageEvent : public Event {
  public:
   MemoryUsageEvent(const char* name, int64_t current, int64_t peak)
-      : current_({"current", current}),
-        peak_({"peak", peak}),
-        Event(name, LogLevel::kHigh) {
+      : Event(name, LogLevel::kHigh),
+        current_({"current", current}),
+        peak_({"peak", peak}) {
     InitAttributes({&current_, &peak_});
   }
 


### PR DESCRIPTION
This PR reorders the initializer list of `MemoryUsageEvent` so that the parent's constructor is called first.