### PR TITLE
Add support for timestamp attribute.

### DIFF
--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -46,6 +46,10 @@ std::string ValueToCSVString(DurationClock::duration value) {
   return std::to_string(ToInt64Nanoseconds(value));
 }
 
+std::string ValueToCSVString(TimestampClock::time_point value) {
+  return std::to_string(ToUnixNanos(value));
+}
+
 // Takes an `Event` instance as an input and generates a csv string containing
 // `event`'s name and attribute values.
 // TODO(miladhakimi): Differentiate hashes and other integers. Hashes
@@ -56,6 +60,11 @@ std::string EventToCSVString(Event &event) {
   std::ostringstream csv_str;
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     switch (attributes[i]->GetValueType()) {
+      case ValueType::kTimestamp: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<TimestampAttr>()->GetValue());
+        break;
+      }
       case ValueType::kDuration: {
         csv_str << ValueToCSVString(
             attributes[i]->cast<DurationAttr>()->GetValue());

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -31,11 +31,12 @@ std::string ValueToCSVString(const std::vector<int64_t> &values);
 // Converts a `DurationClock::duration` to its nanoseconds representation.
 std::string ValueToCSVString(DurationClock::duration value);
 
+// Converts a `TimestampClock::time_point` to its nanoseconds representation.
+std::string ValueToCSVString(TimestampClock::time_point value);
+
 // Takes an `Event` instance as an input and generates a csv string containing
 // `event`'s name and attribute values. The duration values will be logged in
 // nanoseconds.
-// TODO(miladhakimi): Differentiate hashes and other integers. Hashes
-// should be displayed in hex.
 std::string EventToCSVString(Event &event);
 
 // CSVLogger logs the events in the CSV format to the output given in its

--- a/units/common_log_tests.cc
+++ b/units/common_log_tests.cc
@@ -24,8 +24,8 @@ TEST(CommonLogger, MethodCheck) {
   CommonLogger logger(nullptr);
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
-      LogLevel::kHigh);
+      "create_graphics_pipeline", TimestampClock::time_point::min(), hashes,
+      DurationClock::duration(4), LogLevel::kHigh);
   logger.StartLog();
   logger.AddEvent(&pipeline_event);
   logger.Flush();

--- a/units/csv_log_tests.cc
+++ b/units/csv_log_tests.cc
@@ -24,7 +24,8 @@ TEST(CSVLogger, MethodCheck) {
   CSVLogger logger("name,timestamp,pipeline,duration", nullptr);
   VectorInt64Attr hashes("hashes", {2, 3});
   DurationClock::duration dur;
-  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline", 1,
+  CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
+                                              TimestampClock::time_point::min(),
                                               hashes, dur, LogLevel::kHigh);
   logger.StartLog();
   logger.AddEvent(&pipeline_event);

--- a/units/event_log_tests.cc
+++ b/units/event_log_tests.cc
@@ -52,10 +52,10 @@ class TestLogger : public EventLogger {
 };
 
 TEST(Event, AttributeCreation) {
-  const int64_t timestamp_val = 1601314732230797664;
+  TimestampClock::time_point timestamp_val = TimestampClock::time_point::min();
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
-  const Int64Attr timestamp("timestamp", timestamp_val);
+  const TimestampAttr timestamp("timestamp", timestamp_val);
   const StringAttr state("state", "1");
   const VectorInt64Attr pipeline("pipeline", {hash_val1, hash_val2});
   EXPECT_EQ(timestamp.GetName(), "timestamp");
@@ -69,7 +69,7 @@ TEST(Event, AttributeCreation) {
 }
 
 TEST(Event, CreateShaderModuleEventCreation) {
-  const int64_t timestamp_val = 1601314732230797664;
+  TimestampClock::time_point timestamp_val = {};
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   DurationClock::duration duration(1);
   CreateShaderModuleEvent compile_event("compile_time", timestamp_val,
@@ -78,7 +78,7 @@ TEST(Event, CreateShaderModuleEventCreation) {
 }
 
 TEST(Event, ShaderModuleEventCreation) {
-  const int64_t timestamp_val = 1601314732230797664;
+  TimestampClock::time_point timestamp_val = {};
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   DurationClock::duration duration(926318);
   CreateShaderModuleEvent compile_event("compile_time", timestamp_val,
@@ -87,7 +87,7 @@ TEST(Event, ShaderModuleEventCreation) {
 }
 
 TEST(Event, GraphicsPipelinesEventCreation) {
-  const int64_t timestamp_val = 1601314732230797664;
+  TimestampClock::time_point timestamp_val = {};
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
   DurationClock::duration duration(926318);
@@ -100,7 +100,7 @@ TEST(Event, GraphicsPipelinesEventCreation) {
 }
 
 TEST(Event, CreateGraphicsPipelinesEventCreation) {
-  const int64_t timestamp_val = 1601314732230797664;
+  TimestampClock::time_point timestamp_val = {};
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
   DurationClock::duration duration(926318);
@@ -122,10 +122,11 @@ TEST(EventLogger, TestLoggerCreation) {
 TEST(EventLogger, TestLoggerFunctionCalls) {
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
-      LogLevel::kHigh);
+      "create_graphics_pipeline", TimestampClock::time_point::min(), hashes,
+      DurationClock::duration(4), LogLevel::kHigh);
   CreateShaderModuleEvent compile_event(
-      "compile_time", 1, 2, DurationClock::duration(3), LogLevel::kLow);
+      "compile_time", TimestampClock::time_point::min(), 2,
+      DurationClock::duration(3), LogLevel::kLow);
   TestLogger test_logger;
 
   test_logger.AddEvent(&pipeline_event);
@@ -146,10 +147,11 @@ TEST(EventLogger, TestLoggerFunctionCalls) {
 TEST(EventLogger, FilterLoggerInsert) {
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
-      LogLevel::kHigh);
+      "create_graphics_pipeline", TimestampClock::time_point::min(), hashes,
+      DurationClock::duration(4), LogLevel::kHigh);
   CreateShaderModuleEvent compile_event(
-      "compile_time", 1, 2, DurationClock::duration(3), LogLevel::kLow);
+      "compile_time", TimestampClock::time_point::min(), 2,
+      DurationClock::duration(3), LogLevel::kLow);
   TestLogger test_logger;
   FilterLogger filter(&test_logger, LogLevel::kHigh);
   filter.AddEvent(&pipeline_event);
@@ -169,10 +171,11 @@ TEST(EventLogger, BroadcastLoggerCreation) {
 TEST(EventLogger, BroadcastLoggerFunctionCalls) {
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", 1, hashes, DurationClock::duration(4),
-      LogLevel::kHigh);
+      "create_graphics_pipeline", TimestampClock::time_point::min(), hashes,
+      DurationClock::duration(4), LogLevel::kHigh);
   CreateShaderModuleEvent compile_event(
-      "compile_time", 1, 2, DurationClock::duration(3), LogLevel::kLow);
+      "compile_time", TimestampClock::time_point::min(), 2,
+      DurationClock::duration(3), LogLevel::kLow);
   TestLogger test_logger1, test_logger2, test_logger3;
   FilterLogger filter(&test_logger1, LogLevel::kHigh);
   BroadcastLogger broadcast1({&filter, &test_logger2});


### PR DESCRIPTION
By using an Int64Attr as a single number that represents time-related values (duration/timestamp), we would loose the time unit information.

The `TimestampAttr` is an attribute that contains timestamp information. It is a wrapper around a `chrono::system_clock::time_point` variable. This variable has nanoseconds precision and the loggers are responsible for converting it to the desired time unit.