### PR TITLE
Enable `warning-as-error` and fix the errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,13 @@ set(CMAKE_CXX_STANDARD 17)
 # Disable C++ exceptions.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
 
+# Enable warnings.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+if ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety")
+endif()
+
 set(FILESYSTEM_LIB_NAME stdc++fs)
 
 # Abseil requires PIC.

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -76,6 +76,7 @@ RUN  CXX_COMPILER="g++" \
       -DCMAKE_CXX_COMPILER="$CXX_COMPILER" \
       -DCMAKE_BUILD_TYPE="$CONFIG" \
       -DCMAKE_INSTALL_PREFIX=run \
+      -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -Werror -Wno-comment -Wno-return-type" \
       -DVULKAN_HEADERS_INSTALL_DIR=/dependencies/vulkan-headers-build/run \
       -DVULKAN_LOADER_GENERATED_DIR=/dependencies/Vulkan-Loader/loader/generated \
     && cmake --build . \

--- a/layer/common_logging.cc
+++ b/layer/common_logging.cc
@@ -30,6 +30,16 @@ std::string EventToCommonLogStr(Event &event) {
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     csv_str << attributes[i]->GetName() << ":";
     switch (attributes[i]->GetValueType()) {
+      case ValueType::kTimestamp: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<TimestampAttr>()->GetValue());
+        break;
+      }
+      case ValueType::kDuration: {
+        csv_str << ValueToCSVString(
+            attributes[i]->cast<DurationAttr>()->GetValue());
+        break;
+      }
       case ValueType::kBool: {
         csv_str << ValueToCSVString(
             attributes[i]->cast<BoolAttr>()->GetValue());

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -101,7 +101,7 @@ class DurationAttr : public Attribute {
   DurationClock::duration GetValue() const { return value_; };
 
  private:
-  DurationClock::duration value_;
+  DurationClock::duration value_ = DurationClock::duration::min();
 };
 
 // An attribute that keeps the timestamp information as a point in time.

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -149,6 +149,9 @@ class LayerData {
     if (out_ && out_ != stderr) {
       fclose(out_);
     }
+    if (event_log_ && event_log_ != stderr) {
+      fclose(event_log_);
+    }
   }
 
   // Records the dispatch table and instance key that is associated with

--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -29,9 +29,6 @@ namespace {
 // Layer book-keeping information
 // ----------------------------------------------------------------------------
 
-constexpr uint32_t kMemoryUsageLayerVersion = 1;
-constexpr char kLayerName[] = "VK_LAYER_STADIA_memory_usage";
-constexpr char kLayerDescription[] = "Stadia Memory Usage Measuring Layer";
 constexpr char kLogFilenameEnvVar[] = "VK_MEMORY_USAGE_LOG";
 
 // An event that holds memory allocation information (current and peak
@@ -96,9 +93,15 @@ class MemoryUsageLayerData : public LayerDataWithEventLogger {
     current_allocation_size_ -= size;
   }
 
-  uint64_t GetPeakAllocationSize() const { return peak_allocation_size_; }
+  uint64_t GetPeakAllocationSize() const {
+    absl::MutexLock ReaderLock(&memory_hash_lock_);
+    return peak_allocation_size_;
+  }
 
-  uint64_t GetCurrentAllocationSize() const { return current_allocation_size_; }
+  uint64_t GetCurrentAllocationSize() const {
+    absl::MutexLock ReaderLock(&memory_hash_lock_);
+    return current_allocation_size_;
+  }
 
  private:
   mutable absl::Mutex memory_hash_lock_;


### PR DESCRIPTION
Some of the current unhandled warnings cause failures in the imports because the imports consider them as errors.

This PR enables warnings in the `cmake` and sets the `warning-as-error` flag in the CI  (except for `comment` and `return-type` warnings`) so that the CI can catch the warnings that would break the imports. It also fixes some existing warnings such as missing initializations, unhandled switch-case statements, and unclosed files.