### PR TITLE
tests: fix cond jump depends on uninitialised val

### DIFF
--- a/units/csv_log_tests.cc
+++ b/units/csv_log_tests.cc
@@ -23,7 +23,7 @@ namespace {
 TEST(CSVLogger, MethodCheck) {
   CSVLogger logger("name,timestamp,pipeline,duration", nullptr);
   VectorInt64Attr hashes("hashes", {2, 3});
-  DurationClock::duration dur;
+  DurationClock::duration dur(1);
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
                                               TimestampClock::time_point::min(),
                                               hashes, dur, LogLevel::kHigh);


### PR DESCRIPTION
Running tests with valgrind showed this error. Fixing.

Signed-off-by: Nathan Gauër <brioche@google.com>