### PR TITLE
Refactor runtime layer to use `CSVLogger`.

### DIFF
--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -41,7 +41,7 @@ constexpr char kLogFilenameEnvVar[] = "VK_COMPILE_TIME_LOG";
 class CompileTimeEvent : public Event {
  public:
   CompileTimeEvent(const char* name, const std::vector<int64_t>& hash_values,
-                   DurationClock::duration duration)
+                   Duration duration)
       : Event(name, LogLevel::kHigh),
         hash_values_("hashes", hash_values),
         duration_{"duration", duration} {

--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -42,8 +42,8 @@ std::string ValueToCSVString(const std::vector<int64_t> &values) {
   return csv_string.str();
 }
 
-std::string ValueToCSVString(DurationClock::duration value) {
-  return std::to_string(ToInt64Nanoseconds(value));
+std::string ValueToCSVString(Duration value) {
+  return std::to_string(value.ToNanoseconds());
 }
 
 std::string ValueToCSVString(TimestampClock::time_point value) {

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -29,7 +29,7 @@ std::string ValueToCSVString(const int64_t value);
 std::string ValueToCSVString(const std::vector<int64_t> &values);
 
 // Converts a `DurationClock::duration` to its nanoseconds representation.
-std::string ValueToCSVString(DurationClock::duration value);
+std::string ValueToCSVString(Duration value);
 
 // Converts a `TimestampClock::time_point` to its nanoseconds representation.
 std::string ValueToCSVString(TimestampClock::time_point value);

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -89,19 +89,19 @@ class AttributeImpl : public Attribute {
 
 // An attribute that keeps the duration information. The duration variable has
 // nanoseconds precision. The loggers must convert the `duration` returned by
-// `GetValue()` method to their desired time unit(nanoseconds, miliseconds,
+// `GetValue()` method to their desired time unit(nanoseconds, milliseconds,
 // seconds, etc).
 class DurationAttr : public Attribute {
  public:
   static constexpr ValueType id_ = ValueType::kDuration;
 
-  DurationAttr(const char *name, const DurationClock::duration &value)
+  DurationAttr(const char *name, const Duration &value)
       : Attribute(name, ValueType::kDuration), value_(value) {}
 
-  DurationClock::duration GetValue() const { return value_; };
+  Duration GetValue() const { return value_; };
 
  private:
-  DurationClock::duration value_ = DurationClock::duration::min();
+  Duration value_ = DurationClock::duration::min();
 };
 
 // An attribute that keeps the timestamp information as a point in time.
@@ -174,9 +174,8 @@ class Event {
 // ```
 class CreateShaderModuleEvent : public Event {
  public:
-  CreateShaderModuleEvent(const char *name,
-                          int64_t hash_value, DurationClock::duration duration,
-                          LogLevel log_level)
+  CreateShaderModuleEvent(const char *name, int64_t hash_value,
+                          Duration duration, LogLevel log_level)
       : Event(name, log_level),
         hash_value_{"hash", hash_value},
         duration_{"duration", duration} {
@@ -190,10 +189,8 @@ class CreateShaderModuleEvent : public Event {
 
 class CreateGraphicsPipelinesEvent : public Event {
  public:
-  CreateGraphicsPipelinesEvent(const char *name,
-                               VectorInt64Attr &hash_values,
-                               DurationClock::duration duration,
-                               LogLevel log_level)
+  CreateGraphicsPipelinesEvent(const char *name, VectorInt64Attr &hash_values,
+                               Duration duration, LogLevel log_level)
       : Event(name, log_level),
         hash_values_(hash_values),
         duration_{"duration", duration} {

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -51,8 +51,7 @@ const char* StrOrEmpty(const char* str_or_null) {
 
 class FrameTimeEvent : public Event {
  public:
-  FrameTimeEvent(const char* name, DurationClock::duration time_delta,
-                 bool started)
+  FrameTimeEvent(const char* name, Duration time_delta, bool started)
       : Event(name, LogLevel::kHigh),
         time_delta_("frame_time", time_delta),
         started_("started", started) {

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -116,23 +116,6 @@ void LayerData::RemoveInstance(VkInstance instance) {
   instance_keys_map_.erase(key);
 }
 
-void LayerData::LogLine(std::string_view event_type, std::string_view line,
-                        TimestampClock::time_point timestamp) const {
-  WriteLnAndFlush(out_, line);
-  if (event_log_)
-    WriteLnAndFlush(event_log_,
-                    CsvCat(MakeEventLogPrefix(event_type, timestamp), line));
-}
-
-void LayerData::Log(std::string_view event_type, const HashVector& pipeline,
-                    std::string_view prefix) const {
-  // Quote the comma-separated hash value array to always create 2 CSV cells.
-  std::stringstream pipeline_hash_str;
-  pipeline_hash_str << std::quoted(PipelineHashToString(pipeline));
-  std::string pipeline_and_content = CsvCat(pipeline_hash_str.str(), prefix);
-  LogLine(event_type, pipeline_and_content);
-}
-
 DurationClock::duration LayerData::GetTimeDelta() {
   absl::MutexLock lock(&log_time_lock_);
   DurationClock::time_point now = Now();

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -307,17 +307,6 @@ class LayerData {
     return pipeline_hash_map_.at(pipeline);
   }
 
-  // Logs one line to the log file, and to the event log file, if enabled.
-  void LogLine(std::string_view event_type, std::string_view line,
-               TimestampClock::time_point timestamp = GetTimestamp()) const;
-
-  // Logs an arbitrary string prefixed by the given pipeline.
-  // |event_type| is used as the key in the event log file, if enabled.
-  // |pipeline| is any series of integers that represent the pipeline.
-  // We are using the hash of each shader that is part of the pipeline.
-  void Log(std::string_view event_type, const HashVector& pipeline,
-           std::string_view prefix) const;
-
   // Returns the time difference between the last time this method was called
   // and now. The first call is used for initialization and does not calculate
   // the time delta. It returns DurationClock::duration::min() indicating an

--- a/layer/layer_utils.h
+++ b/layer/layer_utils.h
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <ratio>
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
@@ -78,6 +79,24 @@ int64_t ToInt64Nanoseconds(DurationClock::duration duration);
 
 // Converts a chrono time_point to a Unix int64 nanoseconds representation.
 int64_t ToUnixNanos(TimestampClock::time_point time);
+
+// A wrapper around `DurationClock::duration` to keep track of the time unit.
+// When the `Duration` is used, we know it's either created from a
+// `DurationClock::duration` that has nanosecond-level precision or an int that
+// represents duration in nanoseconds.
+class Duration {
+ public:
+  static Duration FromNanoseconds(int64_t nanos) {
+    return Duration(DurationClock::duration(nanos));
+  }
+
+  Duration(DurationClock::duration duration) : duration_{duration} {}
+
+  int64_t ToNanoseconds() const { return ToInt64Nanoseconds(duration_); }
+
+ private:
+  DurationClock::duration duration_;
+};
 
 // Writes |content| to |file| and flushes it.
 void WriteLnAndFlush(FILE* file, std::string_view content);

--- a/units/csv_log_tests.cc
+++ b/units/csv_log_tests.cc
@@ -23,7 +23,7 @@ namespace {
 TEST(CSVLogger, MethodCheck) {
   CSVLogger logger("pipeline,duration", nullptr);
   VectorInt64Attr hashes("hashes", {2, 3});
-  DurationClock::duration dur(1);
+  Duration dur = Duration::FromNanoseconds(1);
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
                                               hashes, dur, LogLevel::kHigh);
   logger.StartLog();

--- a/units/event_log_tests.cc
+++ b/units/event_log_tests.cc
@@ -66,7 +66,7 @@ TEST(Event, AttributeCreation) {
 
 TEST(Event, CreateShaderModuleEventCreation) {
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
-  DurationClock::duration duration(1);
+  Duration duration = Duration::FromNanoseconds(1);
   CreateShaderModuleEvent compile_event("compile_time", hash_val1, duration,
                                         LogLevel::kLow);
   EXPECT_EQ(compile_event.GetNumAttributes(), 2);
@@ -74,7 +74,7 @@ TEST(Event, CreateShaderModuleEventCreation) {
 
 TEST(Event, ShaderModuleEventCreation) {
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
-  DurationClock::duration duration(926318);
+  Duration duration = Duration::FromNanoseconds(926318);
   CreateShaderModuleEvent compile_event("compile_time", hash_val1, duration,
                                         LogLevel::kLow);
   ASSERT_EQ(compile_event.GetNumAttributes(), 2);
@@ -83,7 +83,7 @@ TEST(Event, ShaderModuleEventCreation) {
 TEST(Event, GraphicsPipelinesEventCreation) {
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
-  DurationClock::duration duration(926318);
+  Duration duration = Duration::FromNanoseconds(926318);
 
   VectorInt64Attr hashes("hashes", {hash_val1, hash_val2});
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
@@ -94,7 +94,7 @@ TEST(Event, GraphicsPipelinesEventCreation) {
 TEST(Event, CreateGraphicsPipelinesEventCreation) {
   const int64_t hash_val1 = 0x67d6fd0aaa78a6d8;
   const int64_t hash_val2 = 0x67d390249c2f20ce;
-  DurationClock::duration duration(926318);
+  Duration duration = Duration::FromNanoseconds(926318);
   VectorInt64Attr hashes("hashes", {hash_val1, hash_val2});
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
                                               hashes, duration, LogLevel::kLow);
@@ -112,10 +112,10 @@ TEST(EventLogger, TestLoggerCreation) {
 TEST(EventLogger, TestLoggerFunctionCalls) {
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", hashes, DurationClock::duration(4),
+      "create_graphics_pipeline", hashes, Duration::FromNanoseconds(4),
       LogLevel::kHigh);
   CreateShaderModuleEvent compile_event(
-      "compile_time", 2, DurationClock::duration(3), LogLevel::kLow);
+      "compile_time", 2, Duration::FromNanoseconds(3), LogLevel::kLow);
   TestLogger test_logger;
 
   test_logger.AddEvent(&pipeline_event);
@@ -136,10 +136,10 @@ TEST(EventLogger, TestLoggerFunctionCalls) {
 TEST(EventLogger, FilterLoggerInsert) {
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", hashes, DurationClock::duration(4),
+      "create_graphics_pipeline", hashes, Duration::FromNanoseconds(4),
       LogLevel::kHigh);
   CreateShaderModuleEvent compile_event(
-      "compile_time", 2, DurationClock::duration(3), LogLevel::kLow);
+      "compile_time", 2, Duration::FromNanoseconds(3), LogLevel::kLow);
   TestLogger test_logger;
   FilterLogger filter(&test_logger, LogLevel::kHigh);
   filter.AddEvent(&pipeline_event);
@@ -159,10 +159,10 @@ TEST(EventLogger, BroadcastLoggerCreation) {
 TEST(EventLogger, BroadcastLoggerFunctionCalls) {
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", hashes, DurationClock::duration(4),
+      "create_graphics_pipeline", hashes, Duration::FromNanoseconds(4),
       LogLevel::kHigh);
   CreateShaderModuleEvent compile_event(
-      "compile_time", 2, DurationClock::duration(3), LogLevel::kLow);
+      "compile_time", 2, Duration::FromNanoseconds(3), LogLevel::kLow);
   TestLogger test_logger1, test_logger2, test_logger3;
   FilterLogger filter(&test_logger1, LogLevel::kHigh);
   BroadcastLogger broadcast1({&filter, &test_logger2});


### PR DESCRIPTION
This PR implements RuntimeEvent which is an event that holds hash values, pipline runtime, and the invocation count of the fragmanet and compute shaders. This event is used by `LogAndRemoveQueryPools()`.