### PR TITLE
Add `CommonLogger` to the `LayerDataWithLogger` class.

### DIFF
--- a/layer/common_logging.cc
+++ b/layer/common_logging.cc
@@ -27,49 +27,46 @@ std::string EventToCommonLogStr(Event &event) {
   std::ostringstream csv_str;
   csv_str << event.GetEventName() << "," << event.GetCreationTime().GetName()
           << ":" << ValueToCSVString(event.GetCreationTime().GetValue());
-  csv_str << ",";
-  for (size_t i = 0, e = attributes.size(); i != e; ++i) {
-    csv_str << attributes[i]->GetName() << ":";
-    switch (attributes[i]->GetValueType()) {
+  for (Attribute *attribute : attributes) {
+    csv_str << "," << attribute->GetName() << ":";
+    switch (attribute->GetValueType()) {
       case ValueType::kTimestamp: {
         csv_str << ValueToCSVString(
-            attributes[i]->cast<TimestampAttr>()->GetValue());
+            attribute->cast<TimestampAttr>()->GetValue());
         break;
       }
       case ValueType::kDuration: {
         csv_str << ValueToCSVString(
-            attributes[i]->cast<DurationAttr>()->GetValue());
+            attribute->cast<DurationAttr>()->GetValue());
         break;
       }
       case ValueType::kBool: {
-        csv_str << ValueToCSVString(
-            attributes[i]->cast<BoolAttr>()->GetValue());
+        csv_str << ValueToCSVString(attribute->cast<BoolAttr>()->GetValue());
         break;
       }
       case ValueType::kInt64: {
-        csv_str << ValueToCSVString(
-            attributes[i]->cast<Int64Attr>()->GetValue());
+        csv_str << ValueToCSVString(attribute->cast<Int64Attr>()->GetValue());
         break;
       }
       case ValueType::kString: {
-        csv_str << ValueToCSVString(
-            attributes[i]->cast<StringAttr>()->GetValue());
+        csv_str << ValueToCSVString(attribute->cast<StringAttr>()->GetValue());
         break;
       }
       case ValueType::kVectorInt64: {
         csv_str << ValueToCSVString(
-            attributes[i]->cast<VectorInt64Attr>()->GetValue());
+            attribute->cast<VectorInt64Attr>()->GetValue());
         break;
       }
     }
-    if (i + 1 != e) csv_str << ",";
   }
   return csv_str.str();
 }
 
 CommonLogger::CommonLogger(const char *filename) {
   if (filename) {
-    out_ = fopen(filename, "w");
+    // Since multiple layers open the same file and write to it at the same
+    // time, it's opened in the append mode.
+    out_ = fopen(filename, "a");
     if (!out_) {
       SPL_LOG(ERROR) << "Failed to open " << filename
                      << ". Using stderr as the alternative output.";

--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -202,6 +202,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateComputePipelines,
   std::string pipeline_and_time =
       CsvCat(pipeline_hash_str.str(), ToInt64Nanoseconds(duration));
   layer_data->LogEventOnly("create_compute_pipelines", pipeline_and_time);
+
   return result;
 }
 

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -127,13 +127,13 @@ using StringAttr = AttributeImpl<std::string, ValueType::kString>;
 using Int64Attr = AttributeImpl<int64_t, ValueType::kInt64>;
 using BoolAttr = AttributeImpl<bool, ValueType::kBool>;
 
-// Event represents the base struct for a loggable event. It contains the
+// Event represents the base class for a loggable event. It contains the
 // event's name, creation time, and the level of importance. The creation time
 // is set automatically upon the creation of the event. The derived classes must
 // define and initialize their own set of attributes.
 class Event {
  public:
-  Event(const char *name, LogLevel log_level)
+  Event(const char *name, LogLevel log_level = LogLevel::kLow)
       : name_(name),
         log_level_(log_level),
         creation_time_({"timestamp", GetTimestamp()}) {}

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -235,4 +235,5 @@ void LayerData::DestroyShaderModule(VkDevice device,
   EraseShader(shader_module);
   next_proc(device, shader_module, allocator);
 }
+
 }  // namespace performancelayers

--- a/test/check_event_log.txt
+++ b/test/check_event_log.txt
@@ -5,14 +5,14 @@
 ; Counts the number of memory and frame time logs and check if they are
 ; as expected.
 ; CHECK-DAG:  compile_time_layer_init,{{[0-9]+}}
-; CHECK-DAG:  memory_usage_layer_init,{{[0-9]+}}
+; CHECK-DAG:  memory_usage_layer_init,timestamp:{{[0-9]+}}
 ; CHECK-DAG:  frame_time_layer_init,{{[0-9]+}}
 ; CHECK:      create_shader_module_ns,{{[0-9]+}},[[SHADER1:0x[a-zA-Z0-9]+]],{{[0-9]+}}
 ; CHECK-NEXT: create_shader_module_ns,{{[0-9]+}},[[SHADER2:0x[a-zA-Z0-9]+]],{{[0-9]+}}
 ; CHECK:      shader_module_first_use_slack_ns,{{[0-9]+}},[[SHADER1]],{{[0-9]+}}
 ; CHECK-NEXT: shader_module_first_use_slack_ns,{{[0-9]+}},[[SHADER2]],{{[0-9]+}}
 ; CHECK:      create_graphics_pipelines,{{[0-9]+}},"[[[SHADER1]],[[SHADER2]]]",{{[0-9]+}}
-; CHECK-DAG:  memory_usage_present,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
+; CHECK-DAG:  memory_usage_present,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
 ; CHECK-DAG:  frame_present,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
-; CHECK-DAG:  memory_usage_destroy_device,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
+; CHECK-DAG:  memory_usage_destroy_device,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
 ; CHECK-DAG:  frame_time_layer_exit,{{[0-9]+}},application_exit


### PR DESCRIPTION
This PR:
- Implements a new class, `LayerDataWithCommonLogger`, that contains the `CommonLogger`.
- Adds the new class to the memory usage layer.
- Change the format of the `FileCheck` input for the memory usage shared events.. Issue: #107 