### PR TITLE
Fix `-Wcomment` and `-Wreturn-type` warnings

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -76,7 +76,7 @@ RUN  CXX_COMPILER="g++" \
       -DCMAKE_CXX_COMPILER="$CXX_COMPILER" \
       -DCMAKE_BUILD_TYPE="$CONFIG" \
       -DCMAKE_INSTALL_PREFIX=run \
-      -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -Werror -Wno-comment -Wno-return-type" \
+      -DCMAKE_CXX_FLAGS="-Werror" \
       -DVULKAN_HEADERS_INSTALL_DIR=/dependencies/vulkan-headers-build/run \
       -DVULKAN_LOADER_GENERATED_DIR=/dependencies/Vulkan-Loader/loader/generated \
     && cmake --build . \

--- a/layer/input_buffer.cc
+++ b/layer/input_buffer.cc
@@ -195,6 +195,7 @@ absl::StatusOr<InputBuffer> InputBuffer::Create(
     }
     default:
       assert(false && "Case not handled.");
+      return absl::InternalError("Case not handled");
   }
 }
 

--- a/layer/layer_utils.h
+++ b/layer/layer_utils.h
@@ -160,8 +160,8 @@ class FunctionInterceptor {
 //
 // Sample use:
 // 1. Define a layer-specific macro:
-//    #define SPL_MY_LAYER_FUNC(RETURN_TYPE_, FUNC_NAME_, FUNC_ARGS_)   \
-//      SPL_INTERCEPTED_VULKAN_FUNC(RETURN_TYPE_, MyLayer_, FUNC_NAME_, \
+//    #define SPL_MY_LAYER_FUNC(RETURN_TYPE_, FUNC_NAME_, FUNC_ARGS_)
+//      SPL_INTERCEPTED_VULKAN_FUNC(RETURN_TYPE_, MyLayer_, FUNC_NAME_,
 //                                  FUNC_ARGS_)
 //
 // 2. Define an intercepted function:


### PR DESCRIPTION
gcc complained about one comment in `layer_utils.h`:
```
/performance-layers/layer/layer_utils.h:163:1: error: multi-line comment [-Werror=comment]
  163 | //    #define SPL_MY_LAYER_FUNC(RETURN_TYPE_, FUNC_NAME_, FUNC_ARGS_)   \
      | ^
```

and a missing return in a switch in `input_buffer.cc`. This fixes these warnings and enables them in the CI.

Fixes: https://github.com/google/vulkan-performance-layers/issues/104