### PR TITLE
Refactor compile time layer to use `CommonLogger`.

### DIFF
--- a/layer/common_logging.cc
+++ b/layer/common_logging.cc
@@ -30,6 +30,10 @@ std::string EventToCommonLogStr(Event &event) {
   for (Attribute *attribute : attributes) {
     csv_str << "," << attribute->GetName() << ":";
     switch (attribute->GetValueType()) {
+      case ValueType::kHashAttribute: {
+        csv_str << "0x" << std::hex << attribute->cast<HashAttr>()->GetValue();
+        break;
+      }
       case ValueType::kTimestamp: {
         csv_str << ValueToCSVString(
             attribute->cast<TimestampAttr>()->GetValue());

--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -60,6 +60,11 @@ std::string EventToCSVString(Event &event) {
   std::ostringstream csv_str;
   for (size_t i = 0, e = attributes.size(); i != e; ++i) {
     switch (attributes[i]->GetValueType()) {
+      case kHashAttribute: {
+        csv_str << "0x" << std::hex
+                << attributes[i]->cast<HashAttr>()->GetValue();
+        break;
+      }
       case ValueType::kTimestamp: {
         csv_str << ValueToCSVString(
             attributes[i]->cast<TimestampAttr>()->GetValue());

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -23,7 +23,15 @@
 
 namespace performancelayers {
 // Set of supported value types for an attribute.
-enum ValueType { kBool, kDuration, kInt64, kString, kTimestamp, kVectorInt64 };
+enum ValueType {
+  kBool,
+  kDuration,
+  kHashAttribute,
+  kInt64,
+  kString,
+  kTimestamp,
+  kVectorInt64
+};
 
 // Specifies the importance of an Eventk. Events are logged based on their level
 // of importance. E.g., compile_time.csv only containsk the important compile
@@ -121,11 +129,12 @@ class TimestampAttr : public Attribute {
   TimestampClock::time_point value_;
 };
 
+using BoolAttr = AttributeImpl<bool, ValueType::kBool>;
+using HashAttr = AttributeImpl<int64_t, ValueType::kHashAttribute>;
+using Int64Attr = AttributeImpl<int64_t, ValueType::kInt64>;
+using StringAttr = AttributeImpl<std::string, ValueType::kString>;
 using VectorInt64Attr =
     AttributeImpl<std::vector<int64_t>, ValueType::kVectorInt64>;
-using StringAttr = AttributeImpl<std::string, ValueType::kString>;
-using Int64Attr = AttributeImpl<int64_t, ValueType::kInt64>;
-using BoolAttr = AttributeImpl<bool, ValueType::kBool>;
 
 // Event represents the base class for a loggable event. It contains the
 // event's name, creation time, and the level of importance. The creation time

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -63,7 +63,7 @@ class FrameTimeEvent : public Event {
   BoolAttr started_;
 };
 
-// Frametime exit event. Both `application_exit` and `terminated` events can be
+// Frametime exit event. Both `application_exit` and `terminated` causes can be
 // generated with this `Event`.
 class FrameTimeExitEvent : public Event {
  public:
@@ -83,6 +83,7 @@ class FrameTimeExitEvent : public Event {
   StringAttr cause_;
   Int64Attr frame_ = Int64Attr("frame", -1);
 };
+
 class FrameTimeLayerData : public LayerDataWithCommonLogger {
  public:
   FrameTimeLayerData(char* log_filename, uint64_t exit_frame_num_or_invalid,

--- a/test/check_event_log.txt
+++ b/test/check_event_log.txt
@@ -4,14 +4,14 @@
 ; consistent.
 ; Counts the number of memory and frame time logs and check if they are
 ; as expected.
-; CHECK-DAG:  compile_time_layer_init,{{[0-9]+}}
+; CHECK-DAG:  compile_time_layer_init,timestamp:{{[0-9]+}}
 ; CHECK-DAG:  memory_usage_layer_init,timestamp:{{[0-9]+}}
 ; CHECK-DAG:  frame_time_layer_init,timestamp:{{[0-9]+}}
-; CHECK:      create_shader_module_ns,{{[0-9]+}},[[SHADER1:0x[a-zA-Z0-9]+]],{{[0-9]+}}
-; CHECK-NEXT: create_shader_module_ns,{{[0-9]+}},[[SHADER2:0x[a-zA-Z0-9]+]],{{[0-9]+}}
-; CHECK:      shader_module_first_use_slack_ns,{{[0-9]+}},[[SHADER1]],{{[0-9]+}}
-; CHECK-NEXT: shader_module_first_use_slack_ns,{{[0-9]+}},[[SHADER2]],{{[0-9]+}}
-; CHECK:      create_graphics_pipelines,{{[0-9]+}},"[[[SHADER1]],[[SHADER2]]]",{{[0-9]+}}
+; CHECK:      create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}}
+; CHECK-NEXT: create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER2:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}}
+; CHECK:      shader_module_first_use_slack_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1]],slack:{{[0-9]+}}
+; CHECK-NEXT: shader_module_first_use_slack_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER2]],slack:{{[0-9]+}}
+; CHECK:      create_graphics_pipelines,timestamp:{{[0-9]+}},hashes:"[[[SHADER1]],[[SHADER2]]]",duration:{{[0-9]+}}
 ; CHECK-DAG:  memory_usage_present,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
 ; CHECK-DAG:  frame_present,timestamp:{{[0-9]+}},frame_time:{{[0-9]+}},started:{{[0-9]+}}
 ; CHECK-DAG:  memory_usage_destroy_device,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}


### PR DESCRIPTION
Introduce a new attribute, `HashAttr`, to differentiate between integers and shader hashes when logging.

Update `FileCheck` to use the new format for compile time common logs.

Issues: #107  #112 