### PR TITLE
Refactor `LayerData` to include `CommonLogger`.

### DIFF
--- a/layer/cache_sideload_layer.cc
+++ b/layer/cache_sideload_layer.cc
@@ -56,10 +56,10 @@ class CreateCacheEvent : public Event {
   Int64Attr cache_size_;
 };
 
-class CacheSideloadLayerData : public LayerDataWithCommonLogger {
+class CacheSideloadLayerData : public LayerData {
  public:
   CacheSideloadLayerData(const char* pipeline_cache_path)
-      : LayerDataWithCommonLogger(nullptr, ""),
+      : LayerData(nullptr, ""),
         implicit_pipeline_cache_path_(pipeline_cache_path) {
     Event event("cache_sideload_layer_init");
     LogEvent(&event);

--- a/layer/compile_time_layer.cc
+++ b/layer/compile_time_layer.cc
@@ -82,10 +82,10 @@ class CreateShaderEvent : public Event {
   DurationAttr duration_;
 };
 
-class CompileTimeLayerData : public LayerDataWithCommonLogger {
+class CompileTimeLayerData : public LayerData {
  public:
   CompileTimeLayerData(char* log_filename)
-      : LayerDataWithCommonLogger(log_filename, "Pipeline,Compile Time (ns)") {
+      : LayerData(log_filename, "Pipeline,Compile Time (ns)") {
     Event event("compile_time_layer_init");
     LogEvent(&event);
   }

--- a/layer/event_logging.h
+++ b/layer/event_logging.h
@@ -275,8 +275,11 @@ class FilterLogger : public EventLogger {
 // A subclass of `EventLogger` that forwards all events, start/end, and flushes
 // to all its children. Example: `
 // ```c++
-// BroadCastLogger({&event_logger1,&event_logger2});
+// BroadCastLogger logger({&event_logger1,&event_logger2});
+// Event event = ...;
+// logger.AddEvent(&event);
 // ```
+// `logger` forwards the event to both `event_logger1` and `event_logger2`.
 class BroadcastLogger : public EventLogger {
  public:
   BroadcastLogger(std::vector<EventLogger *> loggers) : loggers_(loggers) {}

--- a/layer/frame_time_layer.cc
+++ b/layer/frame_time_layer.cc
@@ -82,13 +82,12 @@ class FrameTimeExitEvent : public Event {
   Int64Attr frame_ = Int64Attr("frame", -1);
 };
 
-class FrameTimeLayerData : public LayerDataWithCommonLogger {
+class FrameTimeLayerData : public LayerData {
  public:
   FrameTimeLayerData(char* log_filename, uint64_t exit_frame_num_or_invalid,
                      const char* benchmark_watch_filename,
                      const char* benchmark_start_string)
-      : LayerDataWithCommonLogger(log_filename,
-                                  "Frame Time (ns),Benchmark State"),
+      : LayerData(log_filename, "Frame Time (ns),Benchmark State"),
         exit_frame_num_or_invalid_(exit_frame_num_or_invalid),
         benchmark_start_pattern_(StrOrEmpty(benchmark_start_string)) {
     Event event("frame_time_layer_init");

--- a/layer/memory_usage_layer.cc
+++ b/layer/memory_usage_layer.cc
@@ -47,11 +47,10 @@ class MemoryUsageEvent : public Event {
   Int64Attr peak_;
 };
 
-class MemoryUsageLayerData : public LayerDataWithCommonLogger {
+class MemoryUsageLayerData : public LayerData {
  public:
   explicit MemoryUsageLayerData(char* log_filename)
-      : LayerDataWithCommonLogger(log_filename,
-                                  "Current (bytes), peak (bytes)") {
+      : LayerData(log_filename, "Current (bytes), peak (bytes)") {
     Event event("memory_usage_layer_init");
     LogEvent(&event);
   }

--- a/layer/runtime_layer_data.h
+++ b/layer/runtime_layer_data.h
@@ -51,7 +51,7 @@ class RuntimeEvent : public Event {
 // The filename for the log file will be retrieved from the environment variable
 // "VK_RUNTIME_LOG".  If it is unset, then stderr will be used as the
 // log file.
-class RuntimeLayerData : public LayerDataWithCommonLogger {
+class RuntimeLayerData : public LayerData {
  private:
   struct QueryInfo {
     VkQueryPool timestamp_pool;
@@ -62,10 +62,9 @@ class RuntimeLayerData : public LayerDataWithCommonLogger {
 
  public:
   explicit RuntimeLayerData(char* log_filename)
-      : LayerDataWithCommonLogger(
-            log_filename,
-            "Pipeline,Run Time (ns),Fragment Shader Invocations,Compute "
-            "Shader Invocations") {
+      : LayerData(log_filename,
+                  "Pipeline,Run Time (ns),Fragment Shader Invocations,Compute "
+                  "Shader Invocations") {
     Event event("runtime_layer_init");
     LogEvent(&event);
   }


### PR DESCRIPTION
We created the `LayerDataWithCommonLogger` class to incrementally introduce the `CommonLogger` to all the layers and update their corresponding `FileCheck`.

Now that all the layers can log using `CommonLogger` and all the tests pass, it's safe to add it to the `LayerData` and remove the `LayerDataWithCommonLogger` class.

Issue: #69 