### PR TITLE
Fix `vkcube` hanging problem with runtime layer enabled.

### DIFF
--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -40,9 +40,7 @@ check_layer_log() {
 
 export LD_LIBRARY_PATH="${INSTALL_DIR}":"${LD_LIBRARY_PATH-}"
 export VK_INSTANCE_LAYERS=VK_LAYER_STADIA_pipeline_compile_time
-# FIXME(https://github.com/googlestadia/performance-layers/issues/71): Fix
-#       hangs with the runtime layer and re-enable it.
-# export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_runtime
+export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_runtime
 export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_frame_time
 export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_memory_usage
 export VK_INSTANCE_LAYERS=$VK_INSTANCE_LAYERS:VK_LAYER_STADIA_pipeline_cache_sideload

--- a/layer/runtime_layer_data.cc
+++ b/layer/runtime_layer_data.cc
@@ -152,4 +152,19 @@ void RuntimeLayerData::LogAndRemoveQueryPools() {
   }
 }
 
+void RuntimeLayerData::RemoveQueries(const VkCommandBuffer* cmd_buff_list,
+                                     uint32_t cmd_buff_count) {
+  absl::MutexLock lock(&timestamp_queries_lock_);
+  for (size_t i = 0; i < cmd_buff_count; ++i) {
+    for (auto it = timestamp_queries_.begin();
+         it != timestamp_queries_.end();) {
+      if (it->command_buffer == cmd_buff_list[i]) {
+        it = timestamp_queries_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
 }  // namespace performancelayers

--- a/layer/runtime_layer_data.h
+++ b/layer/runtime_layer_data.h
@@ -99,6 +99,10 @@ class RuntimeLayerData : public LayerData {
   // the time spent running each pipeline.
   void LogAndRemoveQueryPools();
 
+  // Removes queries that contain the freed command buffers.
+  void RemoveQueries(const VkCommandBuffer* cmd_buff_list,
+                     uint32_t cmd_buff_count);
+
  private:
   mutable absl::Mutex cmd_buf_to_pipeline_lock_;
   // The map from a command buffer to its bound pipeline.


### PR DESCRIPTION
On ubuntu 22.04, `vkcube` didn't finish when `runtime layer` was enabled. Running `valgrind` showed that `cmd_buff` was accessed after it got freed by `vkcube`. 
```
==2139036== Invalid read of size 8
==2139036==    at 0x15316C85: performancelayers::RuntimeLayerData::LogAndRemoveQueryPools() (in /usr/local/google/home/miladhakimi/performance-layers/build/run/lib/libVkLayer_stadia_pipeline_runtime.so)
==2139036==    by 0x15311D37: (anonymous namespace)::RuntimeLayer_DeviceWaitIdle(VkDevice_T*) (in /usr/local/google/home/miladhakimi/performance-layers/build/run/lib/libVkLayer_stadia_pipeline_runtime.so)
==2139036==    by 0x404B1C: demo_cleanup (cube.c:2392)
==2139036==    by 0x404B1C: main (cube.c:4327)
==2139036==  Address 0x8322320 is 0 bytes inside a block of size 5,680 free'd
==2139036==    at 0x484617B: free (vg_replace_malloc.c:872)
==2139036==    by 0x14C323A3: ??? (in /usr/lib/x86_64-linux-gnu/libvulkan_lvp.so)
==2139036==    by 0x404B01: demo_cleanup (cube.c:2386)
==2139036==    by 0x404B01: main (cube.c:4327)
```
The `cube.c` calls `vkFreeCommandBuffers()` which frees the command buffer. The runtime layer then uses the command buffers without knowing it was freed. Here is  a part of the code of `cube.c` where it frees the command buffer.
```
for (i = 0; i < demo->swapchainImageCount; i++) {
    vkFreeCommandBuffers(demo->device, demo->cmd_pool, 1, &demo->swapchain_image_resources[i].cmd);
    vkDestroyBuffer(demo->device, demo->swapchain_image_resources[i].uniform_buffer, NULL);
}
```
To fix that, we intercept `vkFreeCommandBuffer()` in the runtime layer and get the list of command buffers about to be freed. The `RemoveQueries()` method takes these command buffers and erases the queries that have them.

Fixes: #71 