### PR TITLE
Add runtime layer `FileCheck` to the CI.

### DIFF
--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -17,7 +17,7 @@ readonly LAYER_DIR="${INSTALL_DIR}/run/layer"
 readonly OUTPUT_DIR="$(mktemp -d)"
 
 declare -a output_files
-output_files=("compile_time.csv" "memory_usage.csv"
+output_files=("compile_time.csv" "run_time.csv" "memory_usage.csv"
               "frame_time.csv" "events.log")
 
 #######################################
@@ -60,9 +60,12 @@ for file in "${output_files[@]}"; do
   check_layer_log "${file}"
 done
 
-# Check that log file's contents matches what is expected.
+# Check that log file's contents match what is expected.
 FileCheck "${PROJECT_ROOT_DIR}/test/check_compile_time_log.txt" --input-file \
   "${OUTPUT_DIR}"/compile_time.csv
+
+FileCheck "${PROJECT_ROOT_DIR}/test/check_run_time_log.txt" --input-file \
+  "${OUTPUT_DIR}"/run_time.csv
 
 FileCheck "${PROJECT_ROOT_DIR}/test/check_memory_usage_log.txt" --input-file \
   "${OUTPUT_DIR}"/memory_usage.csv

--- a/test/check_event_log.txt
+++ b/test/check_event_log.txt
@@ -5,6 +5,7 @@
 ; Counts the number of memory and frame time logs and check if they are
 ; as expected.
 ; CHECK-DAG:  compile_time_layer_init,timestamp:{{[0-9]+}}
+; CHECK-DAG:  runtime_layer_init,timestamp:{{[0-9]+}}
 ; CHECK-DAG:  memory_usage_layer_init,timestamp:{{[0-9]+}}
 ; CHECK-DAG:  frame_time_layer_init,timestamp:{{[0-9]+}}
 ; CHECK:      create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}}
@@ -14,5 +15,6 @@
 ; CHECK:      create_graphics_pipelines,timestamp:{{[0-9]+}},hashes:"[[[SHADER1]],[[SHADER2]]]",duration:{{[0-9]+}}
 ; CHECK-DAG:  memory_usage_present,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
 ; CHECK-DAG:  frame_present,timestamp:{{[0-9]+}},frame_time:{{[0-9]+}},started:{{[0-9]+}}
+; CHECK-DAG:  pipeline_execution,timestamp:{{[0-9]+}},pipeline:"[[[SHADER1]],[[SHADER2]]]",runtime:{{[0-9]+}},fragment_shader_invocations:{{[0-9]+}},compute_shader_invocations:{{[0-9]+}}
 ; CHECK-DAG:  memory_usage_destroy_device,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
 ; CHECK-DAG:  frame_time_layer_exit,timestamp:{{[0-9]+}},finish_cause:application_exit

--- a/test/check_run_time_log.txt
+++ b/test/check_run_time_log.txt
@@ -1,0 +1,4 @@
+; Checks the runtime log file pattern. Makes sure the header
+; and the data rows' format are as expected.
+; CHECK-LABEL: Pipeline,Run Time (ns),Fragment Shader Invocations,Compute Shader Invocations
+; CHECK-NEXT: "[{{0x[a-zA-Z0-9]+,0x[a-zA-Z0-9]+}}]",{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}


### PR DESCRIPTION
Now that `vkcube` runs without a problem when the runtime layer is enabled, we can add checks for the runtime layer's logs in the CI. This PR implements the tests for both private and common files.
Fixes: #121 
