### PR TITLE
Refactor `StringOutput` to keep a copy of log strings.

### DIFF
--- a/units/log_output_tests.cc
+++ b/units/log_output_tests.cc
@@ -103,13 +103,13 @@ class StringOutput : public LogOutput {
   void LogLine(std::string_view line) override {
     assert(line.find('\n') == std::string_view::npos &&
            "Expected single line.");
-    out_.push_back(line);
+    out_.push_back(std::string(line));
   }
 
-  const std::vector<std::string_view> &GetLog() { return out_; }
+  const std::vector<std::string> &GetLog() { return out_; }
 
  private:
-  std::vector<std::string_view> out_;
+  std::vector<std::string> out_;
 };
 
 // Used by the tests prior to logging to make sure the underlying file is empty.


### PR DESCRIPTION
In the `AddEvent()` method, the logger generates a log string on the stack and passes it as a `string_view` to the `LogOutput`. If the logger uses `FileOutput`, using `string_view` is fine because there is no need to access the stack-allocated log string after returning from `AddEvent()` as it is persisted to the file. However, `StringOutput` works differently. It keeps the logs in a `vector<string_view>` and reads them after we're done with logging. Hence, it needs to access the logs after we return from the `AddEvent()`.
To fix this, we copy the logs in the `StringOutput` and keep a `vector<string>` instead of `string_view`.
