### PR TITLE
Refactor `CSVLogger` to use `LogOutput` class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(performance_layers_support_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/input_buffer.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_data.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/layer_utils.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer/log_output.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/layer/log_scanner.cc
 )
 target_include_directories(performance_layers_support_lib INTERFACE

--- a/layer/csv_logging.cc
+++ b/layer/csv_logging.cc
@@ -101,18 +101,4 @@ std::string EventToCSVString(Event &event) {
   return csv_str.str();
 }
 
-CSVLogger::CSVLogger(const char *csv_header, const char *filename)
-    : header_(csv_header) {
-  if (filename) {
-    out_ = fopen(filename, "w");
-    if (!out_) {
-      SPL_LOG(ERROR) << "Failed to open " << filename
-                     << ". Using stderr as the alternative output.";
-      out_ = stderr;
-    }
-  } else {
-    out_ = stderr;
-  }
-}
-
 }  // namespace performancelayers

--- a/layer/csv_logging.h
+++ b/layer/csv_logging.h
@@ -20,6 +20,7 @@
 
 #include "event_logging.h"
 #include "layer_utils.h"
+#include "log_output.h"
 
 namespace performancelayers {
 std::string ValueToCSVString(const std::string &value);
@@ -47,35 +48,28 @@ std::string EventToCSVString(Event &event);
 // The only valid methods after calling `EndLog()` is `EndLog()`.
 class CSVLogger : public EventLogger {
  public:
-  CSVLogger(const char *csv_header, const char *filename);
+  CSVLogger(const char *csv_header, LogOutput *out)
+      : header_(csv_header), out_(out) {}
 
   void AddEvent(Event *event) override {
     assert(out_);
     std::string event_str = EventToCSVString(*event);
-    WriteLnAndFlush(out_, event_str);
+    out_->LogLine(event_str);
   }
 
   // Writes the CSV header given in the constructor to the output.
   void StartLog() override {
     assert(out_);
-    WriteLnAndFlush(out_, header_);
+    out_->LogLine(header_);
   }
 
-  void EndLog() override {
-    if (out_ && out_ != stderr) {
-      fclose(out_);
-      out_ = nullptr;
-    }
-  }
+  void EndLog() override {}
 
-  void Flush() override {
-    assert(out_);
-    fflush(out_);
-  }
+  void Flush() override { out_->Flush(); }
 
  private:
-  FILE *out_ = nullptr;
   const char *header_ = nullptr;
+  LogOutput *out_ = nullptr;
 };
 
 }  // namespace performancelayers

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -69,7 +69,8 @@ VkLayerDeviceCreateInfo* FindDeviceCreateInfo(
 }  // namespace
 
 LayerData::LayerData(char* log_filename, const char* header)
-    : private_logger_(CSVLogger(header, log_filename)),
+    : private_output_(log_filename),
+      private_logger_(CSVLogger(header, &private_output_)),
       private_logger_filter_(FilterLogger(&private_logger_, LogLevel::kHigh)),
       common_logger_(getenv(kEventLogFileEnvVar)),
       broadcast_logger_({&private_logger_filter_, &common_logger_}) {

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -33,6 +33,7 @@
 #include "event_logging.h"
 #include "farmhash.h"
 #include "layer_utils.h"
+#include "log_output.h"
 #include "vulkan/vk_layer.h"
 #include "vulkan/vulkan.h"
 #include "vulkan/vulkan_core.h"
@@ -146,12 +147,7 @@ class LayerData {
 
   LayerData(char* log_filename, const char* header);
 
-  virtual ~LayerData() {
-    if (event_log_ && event_log_ != stderr) {
-      fclose(event_log_);
-    }
-    broadcast_logger_.EndLog();
-  }
+  virtual ~LayerData() { broadcast_logger_.EndLog(); }
 
   // Records the dispatch table and instance key that is associated with
   // |instance|.
@@ -402,8 +398,8 @@ class LayerData {
   DurationClock::time_point last_log_time_ ABSL_GUARDED_BY(log_time_lock_) =
       DurationClock::time_point::min();
 
-  // Event log file appended to by multiple layers, or nullptr.
-  FILE* event_log_ = nullptr;
+  FileOutput private_output_;
+
   CSVLogger private_logger_;
   FilterLogger private_logger_filter_;
   CommonLogger common_logger_;

--- a/layer/log_output.cc
+++ b/layer/log_output.cc
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "log_output.h"
+
+#include "debug_logging.h"
+
+namespace performancelayers {
+FileOutput::FileOutput(const char *filename) {
+  if (!filename) {
+    out_ = stderr;
+    return;
+  }
+
+  // Since multiple layers open the same file and write to it at the same
+  // time, it's opened in the append mode.
+  out_ = fopen(filename, "a");
+  if (!out_) {
+    SPL_LOG(ERROR) << "Failed to open " << filename
+                   << ". Using stderr as the alternative output.";
+    out_ = stderr;
+  }
+}
+
+void FileOutput::LogLine(std::string_view line) {
+  assert(out_);
+  assert(line.find('\n') == std::string_view::npos && "Expected single line.");
+  const int line_len = line.length();
+  fprintf(out_, "%.*s\n", line_len, line.data());
+  Flush();
+}
+
+}  // namespace performancelayers

--- a/layer/log_output.h
+++ b/layer/log_output.h
@@ -1,0 +1,78 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOG_OUTPUT_H_
+#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOG_OUTPUT_H_
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace performancelayers {
+// An abstraction over the output. It writes the incoming string to the output.
+class LogOutput {
+ public:
+  virtual ~LogOutput() = default;
+
+  virtual void Flush() = 0;
+
+  virtual void LogLine(std::string_view line) = 0;
+};
+
+// Implements LogOutput for a file. If the given filename is `nullptr`, it
+// writes to the standard output. After each write, the logs are persisted to
+// the file by calling `fflush`. Since only one line is written to the output by
+// each `LogLine()` call, it doens't need to aquire a mutex.
+class FileOutput : public LogOutput {
+ public:
+  FileOutput(const char *filename);
+
+  ~FileOutput() {
+    if (out_ && out_ != stderr) {
+      fclose(out_);
+    }
+  }
+
+  void Flush() override {
+    assert(out_);
+    fflush(out_);
+  }
+
+  void LogLine(std::string_view line) override;
+
+ private:
+  FILE *out_ = nullptr;
+};
+
+// This class is used for testing. It writes the data to a string
+// instead of a file. The data can be read using the `GetLog()` method.
+class StringOutput : public LogOutput {
+ public:
+  StringOutput() = default;
+
+  void Flush() override {}
+
+  void LogLine(std::string_view line) override {
+    assert(line.find('\n') == std::string_view::npos &&
+           "Expected single line.");
+    out_.emplace_back(std::string(line));
+  }
+
+  const std::vector<std::string> &GetLog() { return out_; }
+
+ private:
+  std::vector<std::string> out_;
+};
+}  // namespace performancelayers
+
+#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_LOG_OUTPUT_H_

--- a/units/csv_log_tests.cc
+++ b/units/csv_log_tests.cc
@@ -12,16 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
 #include "csv_logging.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using ::testing::ElementsAre;
 
 namespace performancelayers {
 namespace {
 // This is a simple test and only calls the methods to make sure the
 // logger doesn't crash.
 TEST(CSVLogger, MethodCheck) {
-  CSVLogger logger("pipeline,duration", nullptr);
+  StringOutput out = {};
+  CSVLogger logger("pipeline,duration", &out);
   VectorInt64Attr hashes("hashes", {2, 3});
   Duration dur = Duration::FromNanoseconds(1);
   CreateGraphicsPipelinesEvent pipeline_event("create_graphics_pipeline",
@@ -32,8 +39,8 @@ TEST(CSVLogger, MethodCheck) {
   logger.EndLog();
   // Checks double `EndLog` calls.
   logger.EndLog();
-
-  SUCCEED();
+  std::string_view event_str = "\"[0x2,0x3]\",1";
+  EXPECT_THAT(out.GetLog(), ElementsAre("pipeline,duration", event_str));
 }
 
 }  // namespace


### PR DESCRIPTION
Now, the `CSVLogger` receives a pointer to a`LogOutput` instance in its constructor that determines the type of the output to write the logs into. This is helpful for unit testing the new loggers to make sure their output looks as expected.