### PR TITLE
[CI] Fix clang-format check

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -6,11 +6,11 @@ on:
 jobs:
   clang-format-check:
     name: clang-format
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: Setup environment
         run: |
-          sudo apt-get install -yqq clang-format-9
+          sudo apt-get install -yqq clang-format-14
       - name: Checkout
         run: |
           git clone https://github.com/${{ github.repository }}.git .
@@ -20,7 +20,7 @@ jobs:
       - name: Run clang-format
         run: |
           git diff ${{ github.base_ref }} -U0 --no-color -- '**/*.cpp' '**/*.cc' '**/*.h' '**/*.hh' \
-            | clang-format-diff-9 -p1 >not-formatted.diff 2>&1
+            | clang-format-diff-14 -p1 >not-formatted.diff 2>&1
       - name: Check formatting
         run: |
           if ! grep -q '[^[:space:]]' not-formatted.diff ; then


### PR DESCRIPTION
Upgrade the OS image to ubuntu 22.04. Upgrade clang-format version to 14 to match the toolchain in the docker build.