### PR TITLE
Refactor `CommonLogger` to use `LogOutput`.

### DIFF
--- a/layer/common_logging.cc
+++ b/layer/common_logging.cc
@@ -66,19 +66,4 @@ std::string EventToCommonLogStr(Event &event) {
   return csv_str.str();
 }
 
-CommonLogger::CommonLogger(const char *filename) {
-  if (filename) {
-    // Since multiple layers open the same file and write to it at the same
-    // time, it's opened in the append mode.
-    out_ = fopen(filename, "a");
-    if (!out_) {
-      SPL_LOG(ERROR) << "Failed to open " << filename
-                     << ". Using stderr as the alternative output.";
-      out_ = stderr;
-    }
-  } else {
-    out_ = stderr;
-  }
-}
-
 }  // namespace performancelayers

--- a/layer/common_logging.h
+++ b/layer/common_logging.h
@@ -21,6 +21,7 @@
 
 #include "event_logging.h"
 #include "layer_utils.h"
+#include "log_output.h"
 
 namespace performancelayers {
 // Converts `event` to a string with the common log format. The common log
@@ -33,30 +34,22 @@ std::string EventToCommonLogStr(Event &event);
 // stderr. The only valid methods after calling `EndLog()` is `EndLog()`.
 class CommonLogger : public EventLogger {
  public:
-  CommonLogger(const char *filename);
+  CommonLogger(LogOutput *out) : out_(out){};
 
   void AddEvent(Event *event) override {
     assert(out_);
     std::string event_str = EventToCommonLogStr(*event);
-    WriteLnAndFlush(out_, event_str);
+    out_->LogLine(event_str);
   }
 
   void StartLog() override {}
 
-  void EndLog() override {
-    if (out_ && out_ != stderr) {
-      fclose(out_);
-      out_ = nullptr;
-    }
-  }
+  void EndLog() override {}
 
-  void Flush() override {
-    assert(out_);
-    fflush(out_);
-  }
+  void Flush() override {}
 
  private:
-  FILE *out_ = nullptr;
+  LogOutput *out_ = nullptr;
 };
 
 }  // namespace performancelayers

--- a/layer/layer_data.cc
+++ b/layer/layer_data.cc
@@ -69,10 +69,11 @@ VkLayerDeviceCreateInfo* FindDeviceCreateInfo(
 }  // namespace
 
 LayerData::LayerData(char* log_filename, const char* header)
-    : private_output_(log_filename),
+    : common_output_(getenv(kEventLogFileEnvVar)),
+      private_output_(log_filename),
       private_logger_(CSVLogger(header, &private_output_)),
       private_logger_filter_(FilterLogger(&private_logger_, LogLevel::kHigh)),
-      common_logger_(getenv(kEventLogFileEnvVar)),
+      common_logger_(&common_output_),
       broadcast_logger_({&private_logger_filter_, &common_logger_}) {
   broadcast_logger_.StartLog();
 }

--- a/layer/layer_data.h
+++ b/layer/layer_data.h
@@ -398,6 +398,7 @@ class LayerData {
   DurationClock::time_point last_log_time_ ABSL_GUARDED_BY(log_time_lock_) =
       DurationClock::time_point::min();
 
+  FileOutput common_output_;
   FileOutput private_output_;
 
   CSVLogger private_logger_;


### PR DESCRIPTION
The `CommonLogger` receives a `LogOutput` pointer in its constructor that determines the type of output it wants to write the logs into.