### PR TITLE
Spawn fewer threads in `LogOutput.MultiThreadedFileLog`

### DIFF
--- a/units/log_output_tests.cc
+++ b/units/log_output_tests.cc
@@ -35,7 +35,7 @@ using ::testing::TempDir;
 namespace performancelayers {
 namespace {
 constexpr unsigned kLogsPerThread = 1337;
-constexpr unsigned kThreadCount = 100;
+constexpr unsigned kThreadCount = 8;
 
 // Used by the tests prior to logging to make sure the underlying file is empty.
 void CreateEmptyFile(const std::string &filename) {


### PR DESCRIPTION
This decreases the test case runtime from 850ms to 50ms on my machine.

In my experience, TSan should be effective even with 8 threads or fewer.