### PR TITLE
Implement the `Timestamp` class to ease the usage of `time_point`.

### DIFF
--- a/layer/support/csv_logging.cc
+++ b/layer/support/csv_logging.cc
@@ -46,8 +46,8 @@ std::string ValueToCSVString(Duration value) {
   return std::to_string(value.ToNanoseconds());
 }
 
-std::string ValueToCSVString(TimestampClock::time_point value) {
-  return std::to_string(ToUnixNanos(value));
+std::string ValueToCSVString(Timestamp value) {
+  return std::to_string(value.ToNanoseconds());
 }
 
 // Takes an `Event` instance as an input and generates a csv string containing

--- a/layer/support/csv_logging.h
+++ b/layer/support/csv_logging.h
@@ -29,11 +29,11 @@ std::string ValueToCSVString(const int64_t value);
 
 std::string ValueToCSVString(const std::vector<int64_t> &values);
 
-// Converts a `DurationClock::duration` to its nanoseconds representation.
+// Converts a `Duration` to its nanoseconds representation.
 std::string ValueToCSVString(Duration value);
 
-// Converts a `TimestampClock::time_point` to its nanoseconds representation.
-std::string ValueToCSVString(TimestampClock::time_point value);
+// Converts a `Timestamp` to its nanoseconds representation.
+std::string ValueToCSVString(Timestamp value);
 
 // Takes an `Event` instance as an input and generates a csv string containing
 // `event`'s name and attribute values. The duration values will be logged in

--- a/layer/support/event_logging.h
+++ b/layer/support/event_logging.h
@@ -123,13 +123,13 @@ class TimestampAttr : public Attribute {
  public:
   static constexpr ValueType id_ = ValueType::kTimestamp;
 
-  TimestampAttr(const char *name, const TimestampClock::time_point &value)
+  TimestampAttr(const char *name, const Timestamp &value)
       : Attribute(name, ValueType::kTimestamp), value_(value) {}
 
-  TimestampClock::time_point GetValue() const { return value_; };
+  Timestamp GetValue() const { return value_; };
 
  private:
-  TimestampClock::time_point value_;
+  Timestamp value_;
 };
 
 using BoolAttr = AttributeImpl<bool, ValueType::kBool>;
@@ -219,14 +219,12 @@ class Event {
         log_level_(log_level),
         creation_time_({"timestamp", GetTimestamp()}) {}
 
-  Event(const char *name, int64_t timestamp,
+  Event(const char *name, int64_t timestamp_ns,
         LogLevel log_level = LogLevel::kLow)
       : name_(name),
         log_level_(log_level),
         creation_time_(
-            {"timestamp",
-             TimestampClock::time_point(TimestampClock::duration(timestamp))}) {
-  }
+            {"timestamp", Timestamp::FromNanoseconds(timestamp_ns)}) {}
 
   virtual ~Event() = default;
 

--- a/layer/support/layer_utils.cc
+++ b/layer/support/layer_utils.cc
@@ -21,15 +21,6 @@ TimestampClock::time_point GetTimestamp() { return TimestampClock::now(); }
 
 DurationClock::time_point Now() { return DurationClock::now(); }
 
-int64_t ToUnixNanos(TimestampClock::time_point time) {
-  return std::chrono::nanoseconds(time.time_since_epoch()).count();
-}
-
-double ToUnixMillis(TimestampClock::time_point time) {
-  return std::chrono::duration<double, std::milli>(time.time_since_epoch())
-      .count();
-}
-
 FunctionInterceptor::FunctionInterceptor(
     InterceptedVulkanFunc intercepted_function) {
   FunctionNameToPtr& registered_functions = GetInterceptedFunctions();

--- a/layer/unittest/common_log_tests.cc
+++ b/layer/unittest/common_log_tests.cc
@@ -30,7 +30,7 @@ TEST(CommonLogger, MethodCheck) {
   CommonLogger logger(&out);
   VectorInt64Attr hashes("hashes", {2, 3});
   CreateGraphicsPipelinesEvent pipeline_event(
-      "create_graphics_pipeline", hashes, DurationClock::duration(4),
+      "create_graphics_pipeline", hashes, Duration::FromNanoseconds(4),
       LogLevel::kHigh);
   logger.StartLog();
   logger.AddEvent(&pipeline_event);
@@ -41,7 +41,7 @@ TEST(CommonLogger, MethodCheck) {
 
   std::stringstream event_str;
   int64_t timestamp_in_ns =
-      ToUnixNanos(pipeline_event.GetCreationTime().GetValue());
+      pipeline_event.GetCreationTime().GetValue().ToNanoseconds();
   event_str << "create_graphics_pipeline,timestamp:" << timestamp_in_ns
             << ",hashes:\"[0x2,0x3]\",duration:4";
   EXPECT_THAT(out.GetLog(), ElementsAre(event_str.str()));

--- a/layer/unittest/trace_event_log_tests.cc
+++ b/layer/unittest/trace_event_log_tests.cc
@@ -56,8 +56,8 @@ std::string ValueToJsonString(Duration value) {
 
 // Converts the timestamp to milliseconds, the defualt time unit in the `Trace
 // Event` format.
-std::string ValueToJsonString(TimestampClock::time_point value) {
-  return std::to_string(ToUnixMillis(value));
+std::string ValueToJsonString(Timestamp value) {
+  return std::to_string(value.ToMilliseconds());
 }
 
 // Appends all given attributes, including the type-specific attribute, to the
@@ -117,7 +117,7 @@ void AppendCompleteEvent(TimestampAttr timestamp,
   assert(duration_attr && "Duration not found.");
 
   double duration_ms = duration_attr->GetValue().ToMilliseconds();
-  double end_timestamp_ms = ToUnixMillis(timestamp.GetValue());
+  double end_timestamp_ms = timestamp.GetValue().ToMilliseconds();
   double start_timestamp_ms = end_timestamp_ms - duration_ms;
   json_stream << ", " << std::quoted("ts") << " : " << std::fixed
               << start_timestamp_ms << ", " << std::quoted("dur") << " : "


### PR DESCRIPTION
- Allows creating `time_point`s from int values.
- Keeps track of timestamps' time unit.