### PR TITLE
Add `TraceEventLogger` to the compile time layer.

### DIFF
--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -51,6 +51,7 @@ export VK_RUNTIME_LOG="${OUTPUT_DIR}"/run_time.csv
 export VK_FRAME_TIME_LOG="${OUTPUT_DIR}"/frame_time.csv
 export VK_MEMORY_USAGE_LOG="${OUTPUT_DIR}"/memory_usage.csv
 export VK_PERFORMANCE_LAYERS_EVENT_LOG_FILE="${OUTPUT_DIR}"/events.log
+export VK_PERFORMANCE_LAYERS_TRACE_EVENT_LOG_FILE="${OUTPUT_DIR}"/trace_events.log
 
 # Test if an application can run with performance layers enabled.
 xvfb-run vkcube --c 100

--- a/layer/support/CMakeLists.txt
+++ b/layer/support/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(performance_layers_support_lib INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/layer_utils.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/log_output.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/log_scanner.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/trace_event_logging.cc
 )
 
 target_include_directories(performance_layers_support_lib INTERFACE

--- a/layer/support/common_logging.h
+++ b/layer/support/common_logging.h
@@ -29,10 +29,8 @@ namespace performancelayers {
 // `event_name,attribute1_name:attribute1_value,attribute2_name:attribute2_value,...`
 std::string EventToCommonLogStr(Event &event);
 
-// CommonLogger logs the events in the common log. There is no need to add '\n'
-// at the end of the input of the `AddEvent()` method. This is handled by the
-// implementation. The only valid methods after calling `EndLog()` is
-// `EndLog()`.
+// CommonLogger logs the events in the common log. The only valid method after
+// calling `EndLog()` is `EndLog()`.
 class CommonLogger : public EventLogger {
  public:
   CommonLogger(LogOutput *out) : out_(out){};

--- a/layer/support/csv_logging.cc
+++ b/layer/support/csv_logging.cc
@@ -32,11 +32,11 @@ std::string ValueToCSVString(const int64_t value) {
 
 std::string ValueToCSVString(const std::vector<int64_t> &values) {
   std::ostringstream csv_string;
-  csv_string << "\"[";
+  csv_string << "\"[" << std::hex;
   size_t e = values.size();
   for (size_t i = 0; i != e; ++i) {
     const char *delimiter = i < e - 1 ? "," : "";
-    csv_string << "0x" << std::hex << values[i] << delimiter;
+    csv_string << "0x" << values[i] << delimiter;
   }
   csv_string << "]\"";
   return csv_string.str();

--- a/layer/support/csv_logging.h
+++ b/layer/support/csv_logging.h
@@ -42,9 +42,8 @@ std::string EventToCSVString(Event &event);
 
 // CSVLogger logs the events in the CSV format to the output given in its
 // constructor. There is no need to add '\n' at the end of the csv_header in the
-// constructor, or the input of the `AddEvent()` method. This is handled by the
-// implementation. The only valid methods after calling `EndLog()` is
-// `EndLog()`.
+// constructor. This is handled by the implementation. The only valid method
+// after calling `EndLog()` is `EndLog()`.
 class CSVLogger : public EventLogger {
  public:
   CSVLogger(const char *csv_header, LogOutput *out)

--- a/layer/support/event_logging.h
+++ b/layer/support/event_logging.h
@@ -173,6 +173,10 @@ class TraceEventAttr : public Attribute {
     args_ = {args.begin(), args.end()};
   }
 
+  TraceEventAttr(const char *name, const char *cat, const char *phase,
+                 std::initializer_list<Attribute *> args)
+      : TraceEventAttr(name, cat, phase, GetProcessId(), GetThreadId(), args) {}
+
   const StringAttr &GetCategory() const { return category_; }
 
   const StringAttr &GetPhase() const { return phase_; }

--- a/layer/support/layer_utils.cc
+++ b/layer/support/layer_utils.cc
@@ -15,8 +15,33 @@
 #include "layer/support/layer_utils.h"
 
 #include <cassert>
+#include <cstdint>
+
+#ifdef __linux__
+#include <sys/types.h>
+#include <unistd.h>
+#endif
 
 namespace performancelayers {
+
+int64_t GetThreadId() {
+#ifdef __linux__
+  static thread_local int64_t tid = gettid();
+  return tid;
+#else
+  return 0;
+#endif
+}
+
+int64_t GetProcessId() {
+#ifdef __linux__
+  static int64_t pid = getpid();
+  return pid;
+#else
+  return 0;
+#endif
+}
+
 TimestampClock::time_point GetTimestamp() { return TimestampClock::now(); }
 
 DurationClock::time_point Now() { return DurationClock::now(); }

--- a/layer/support/layer_utils.h
+++ b/layer/support/layer_utils.h
@@ -56,6 +56,17 @@
       reinterpret_cast<PFN_vk##FUNC_NAME_>(gdpa(*device, "vk" #FUNC_NAME_))
 
 namespace performancelayers {
+
+// Returns the thread id of the caller.
+// TODO: This function works only on linux. We should add support for other
+// operating systems.
+int64_t GetThreadId();
+
+// Returns the process id of the caller.
+// TODO: This function works only on linux. We should add support for other
+// operating systems.
+int64_t GetProcessId();
+
 // steady_clock, system_clock, and high_resolution_clock comparison:
 // 1. steady_clock: A monotonic clock. The current value of steady_clock does
 // not matter, but the guarantee that is strictly increasing is useful for

--- a/layer/support/trace_event_logging.cc
+++ b/layer/support/trace_event_logging.cc
@@ -1,0 +1,154 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "layer/support/event_logging.h"
+#include "layer/support/layer_utils.h"
+
+namespace performancelayers {
+std::string ValueToJsonString(bool value) { return value ? "true" : "false"; }
+
+std::string ValueToJsonString(int64_t value) { return std::to_string(value); }
+
+std::string ValueToJsonString(const std::vector<int64_t> &values) {
+  std::ostringstream json_str;
+  json_str << "[" << std::hex;
+  size_t e = values.size();
+  for (size_t i = 0; i != e; ++i) {
+    const char *delimiter = i < e - 1 ? ", " : "";
+    json_str << "\"0x" << values[i] << "\"" << delimiter;
+  }
+  json_str << "]";
+  return json_str.str();
+}
+
+std::string ValueToJsonString(Duration value) {
+  return std::to_string(value.ToMilliseconds());
+}
+
+std::string ValueToJsonString(Timestamp value) {
+  return std::to_string(value.ToMilliseconds());
+}
+
+void TraceArgsToJsonString(const std::vector<Attribute *> &args,
+                           std::ostringstream &json_str) {
+  json_str << ", " << std::quoted("args") << " : { ";
+  for (size_t i = 0, e = args.size(); i < e; ++i) {
+    json_str << std::quoted(args[i]->GetName()) << " : ";
+    switch (args[i]->GetValueType()) {
+      case kHashAttribute: {
+        json_str << "\"0x" << std::hex << args[i]->cast<HashAttr>()->GetValue()
+                 << "\"";
+        break;
+      }
+      case ValueType::kTimestamp: {
+        json_str << ValueToJsonString(
+            args[i]->cast<TimestampAttr>()->GetValue());
+        break;
+      }
+      case ValueType::kDuration: {
+        json_str << ValueToJsonString(
+            args[i]->cast<DurationAttr>()->GetValue());
+        break;
+      }
+      case ValueType::kBool: {
+        json_str << ValueToJsonString(args[i]->cast<BoolAttr>()->GetValue());
+        break;
+      }
+      case ValueType::kInt64: {
+        json_str << ValueToJsonString(args[i]->cast<Int64Attr>()->GetValue());
+        break;
+      }
+      case ValueType::kString: {
+        json_str << std::quoted(args[i]->cast<StringAttr>()->GetValue());
+        break;
+      }
+      case ValueType::kVectorInt64: {
+        json_str << ValueToJsonString(
+            args[i]->cast<VectorInt64Attr>()->GetValue());
+        break;
+      }
+      case ValueType::kTraceEvent:
+        break;
+    }
+    if (i + 1 != e) json_str << ", ";
+  }
+  json_str << " }";
+}
+
+void AppendCompleteEvent(TimestampAttr timestamp,
+                         const TraceEventAttr *trace_event,
+                         std::ostringstream &json_stream) {
+  const DurationAttr *duration_attr = trace_event->GetArg<DurationAttr>();
+  assert(duration_attr && "Duration not found.");
+
+  double duration_ms = duration_attr->GetValue().ToMilliseconds();
+  double end_timestamp_ms = timestamp.GetValue().ToMilliseconds();
+  double start_timestamp_ms = end_timestamp_ms - duration_ms;
+  json_stream << ", " << std::quoted("ts") << " : " << std::fixed
+              << start_timestamp_ms << ", " << std::quoted("dur") << " : "
+              << duration_ms;
+}
+
+void AppendInstantEvent(TimestampAttr timestamp,
+                        const TraceEventAttr *trace_event,
+                        std::ostringstream &json_stream) {
+  const StringAttr *scope_attr = trace_event->GetArg<StringAttr>("scope");
+  assert(scope_attr && "Scope not found.");
+
+  std::string_view scope = scope_attr->GetValue();
+  assert((scope == "g" || scope == "p" || scope == "t") &&
+         "Invalid scope. Scope must be \"g\", \"p\", or \"t\".");
+
+  json_stream << ", " << std::quoted("ts") << " : "
+              << ValueToJsonString(timestamp.GetValue()) << ", "
+              << std::quoted("s") << " : " << std::quoted(scope);
+}
+
+std::string EventToTraceEventString(Event &event) {
+  const TraceEventAttr *trace_attr = event.GetAttribute<TraceEventAttr>();
+  assert(trace_attr && "Could not find TraceEventAttr in the event.");
+
+  std::ostringstream json_stream;
+  std::string_view phase_str = trace_attr->GetPhase().GetValue();
+
+  json_stream << "{ " << std::quoted("name") << " : "
+              << std::quoted(event.GetEventName()) << ", " << std::quoted("ph")
+              << " : " << std::quoted(phase_str) << ", " << std::quoted("cat")
+              << " : " << std::quoted(trace_attr->GetCategory().GetValue())
+              << ", " << std::quoted("pid") << " : "
+              << trace_attr->GetPid().GetValue() << ", " << std::quoted("tid")
+              << " : " << trace_attr->GetTid().GetValue();
+
+  if (phase_str == "X") {
+    AppendCompleteEvent(event.GetCreationTime(), trace_attr, json_stream);
+  } else if (phase_str == "i") {
+    AppendInstantEvent(event.GetCreationTime(), trace_attr, json_stream);
+  } else {
+    assert(false &&
+           "Unrecognized phase.\nPhase should be either \"X\" or \"i\".");
+  }
+
+  TraceArgsToJsonString(trace_attr->GetArgs(), json_stream);
+
+  json_stream << " },";
+  return json_stream.str();
+}
+
+}  // namespace performancelayers

--- a/layer/support/trace_event_logging.h
+++ b/layer/support/trace_event_logging.h
@@ -1,0 +1,88 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_TRACE_EVENT_LOGGING_H_
+#define STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_TRACE_EVENT_LOGGING_H_
+
+#include <string>
+#include <vector>
+
+#include "layer/support/event_logging.h"
+#include "layer/support/log_output.h"
+
+namespace performancelayers {
+std::string ValueToJsonString(bool value);
+
+std::string ValueToJsonString(int64_t value);
+
+std::string ValueToJsonString(const std::vector<int64_t> &values);
+
+// Converts the duration to milliseconds, the defualt time unit in the `Trace
+// Event` format.
+std::string ValueToJsonString(Duration value);
+
+// Converts the timestamp to milliseconds, the defualt time unit in the `Trace
+// Event` format.
+std::string ValueToJsonString(Timestamp value);
+
+// Appends all given attributes, including the type-specific attribute, to the
+// stream.
+void TraceArgsToJsonString(const std::vector<Attribute *> &args,
+                           std::ostringstream &json_str);
+
+// Appends the start timestamp and the duration of a `TraceEventAttr` to the
+// given stream.
+void AppendCompleteEvent(TimestampAttr timestamp,
+                         const TraceEventAttr *trace_event,
+                         std::ostringstream &json_stream);
+
+// Appends the timestamp and the scope of a `TraceEventAttr` to the given
+// stream.
+void AppendInstantEvent(TimestampAttr timestamp,
+                        const TraceEventAttr *trace_event,
+                        std::ostringstream &json_stream);
+
+// Converts an `Event` containing `TraceEventAttr` to a JSON string in the Trace
+// Event format.
+std::string EventToTraceEventString(Event &event);
+
+// Logs the events in the Trace Event format to the output given in its
+// constructor. The only valid method after calling `EndLog()` is `EndLog()`.
+class TraceEventLogger : public EventLogger {
+ public:
+  TraceEventLogger(LogOutput *out) : out_(out) { assert(out); }
+
+  void AddEvent(Event *event) override {
+    if (!event->GetAttribute<TraceEventAttr>()) return;
+    std::string event_str = EventToTraceEventString(*event);
+    out_->LogLine(event_str);
+  }
+
+  // Writes '[', indicating the start point of the JSON array.
+  void StartLog() override { out_->LogLine("["); }
+
+  // The ']' at the end of the JSON array is optional in the Trace Event format.
+  // We exploit this and do not write ']' at the end of the log to allow
+  // multiple layers write into the same file.
+  void EndLog() override {}
+
+  void Flush() override { out_->Flush(); }
+
+ private:
+  LogOutput *out_ = nullptr;
+};
+
+}  // namespace performancelayers
+
+#endif  // STADIA_OPEN_SOURCE_PERFORMANCE_LAYERS_TRACE_EVENT_LOGGING_H_


### PR DESCRIPTION
- Move `TraceEventLogger` and its helper functions to a new header and source files.
- Implement `LayerDataWithTraceEventLogger`, a wrapper that adds the new logger to `LayerData`.
- Add `TraceEventAttr` to all of the compile time layer's events.
- Update the env vars exported in the CI script.