### PR TITLE
Fix formatting problem in float to string conversion.

### DIFF
--- a/layer/support/layer_utils.h
+++ b/layer/support/layer_utils.h
@@ -135,6 +135,10 @@ class Timestamp {
         .count();
   }
 
+  Timestamp operator-(const Duration& duration) {
+    return timestamp_ - DurationClock::duration(duration.ToNanoseconds());
+  }
+
  private:
   TimestampClock::time_point timestamp_;
 };

--- a/layer/unittest/trace_event_log_tests.cc
+++ b/layer/unittest/trace_event_log_tests.cc
@@ -208,7 +208,7 @@ TEST(TraceEvent, CompleteEventToString) {
                                            123, 321);
 
   std::string_view expected_str =
-      R"({ "name" : "compile_time", "ph" : "X", "cat" : "pipeline", "pid" : 123, "tid" : 321, "ts" : 0.000401, "dur" : 0.001000, "args" : { "duration" : 0.001000 } },)";
+      R"({ "name" : "compile_time", "ph" : "X", "cat" : "pipeline", "pid" : 123, "tid" : 321, "ts" : 0.000401, "dur" : 0.001, "args" : { "duration" : 0.001 } },)";
   EXPECT_EQ(EventToTraceEventString(complete_event), expected_str);
 }
 
@@ -286,7 +286,7 @@ TEST(TraceEventLogger, LogDifferentTypes) {
       R"({ "name" : "compile_time_init", "ph" : "i", "cat" : "compile_time", "pid" : 123, "tid" : 321, "ts" : 0.001401, "s" : "g", "args" : { "scope" : "g" } },)";
 
   std::string_view complete_expected_str =
-      R"({ "name" : "compile_time", "ph" : "X", "cat" : "pipeline", "pid" : 321, "tid" : 123, "ts" : 0.000401, "dur" : 0.001000, "args" : { "duration" : 0.001000 } },)";
+      R"({ "name" : "compile_time", "ph" : "X", "cat" : "pipeline", "pid" : 321, "tid" : 123, "ts" : 0.000401, "dur" : 0.001, "args" : { "duration" : 0.001 } },)";
   EXPECT_THAT(out.GetLog(),
               ElementsAre("[", instant_expected_str, complete_expected_str));
 }


### PR DESCRIPTION
`ostringstream` mixes the formatting of the floats. To represent floats, instead of relying on the stream to handle the float to string conversion, we use `std::to_chars` with `fixed` format.

The size of the string representing the number is unknown and varies from one input to the other. Hence, the input buffer given to `std::to_chars` is dynamically allocated and resized to fit  the number.

The size of the buffer might become more than the size of the characters written to it. Although all the rest of the characters are `'\0'`, writing it to a `ostringstream` copies the whole buffer because `ostringstream` uses the size of the string to perform the copy. By calling the `.data()`, the function copies the characters up until the first `'\0'` and does not copy the rest.