### PR TITLE
Replace`DurationCLock::duration` with `Duration` class.

### DIFF
--- a/layer/compile_time/compile_time_layer.cc
+++ b/layer/compile_time/compile_time_layer.cc
@@ -122,7 +122,7 @@ class CompileTimeLayerData : public LayerDataWithTraceEventLogger {
   // use of this shader module, adds an event with the time since shader
   // module creation.
   void RecordShaderModuleUse(VkShaderModule shader) {
-    DurationClock::duration first_use_slack_ns = DurationClock::duration::min();
+    Duration first_use_slack_ns = Duration::Min();
 
     {
       absl::MutexLock lock(&shader_module_usage_lock_);
@@ -138,7 +138,7 @@ class CompileTimeLayerData : public LayerDataWithTraceEventLogger {
       }
     }
 
-    if (first_use_slack_ns != DurationClock::duration::min()) {
+    if (first_use_slack_ns != Duration::Min()) {
       const uint64_t hash = GetShaderHash(shader);
       ShaderModuleSlackEvent event("shader_module_first_use_slack_ns", hash,
                                    first_use_slack_ns);
@@ -230,7 +230,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateComputePipelines,
   auto result = next_proc(device, pipeline_cache, create_info_count,
                           create_infos, alloc_callbacks, pipelines);
   DurationClock::time_point end = Now();
-  DurationClock::duration duration = end - start;
+  Duration duration = end - start;
 
   LayerData::HashVector hashes;
   for (uint32_t i = 0; i < create_info_count; ++i) {
@@ -271,7 +271,7 @@ SPL_COMPILE_TIME_LAYER_FUNC(VkResult, CreateGraphicsPipelines,
   auto result = next_proc(device, pipeline_cache, create_info_count,
                           create_infos, alloc_callbacks, pipelines);
   DurationClock::time_point end = Now();
-  DurationClock::duration duration = end - start;
+  Duration duration = end - start;
 
   LayerData::HashVector hashes;
   for (uint32_t i = 0; i < create_info_count; ++i) {

--- a/layer/frame_time/frame_time_layer.cc
+++ b/layer/frame_time/frame_time_layer.cc
@@ -211,8 +211,8 @@ SPL_FRAME_TIME_LAYER_FUNC(VkResult, QueuePresentKHR,
                            const VkPresentInfoKHR* present_info)) {
   auto* layer_data = GetLayerData();
 
-  DurationClock::duration logged_delta = layer_data->GetTimeDelta();
-  if (logged_delta != DurationClock::duration::min()) {
+  Duration logged_delta = layer_data->GetTimeDelta();
+  if (logged_delta != Duration::Min()) {
     FrameTimeEvent event("frame_present", logged_delta,
                          layer_data->HasBenchmarkStarted());
     layer_data->LogEvent(&event);

--- a/layer/support/event_logging.h
+++ b/layer/support/event_logging.h
@@ -112,7 +112,7 @@ class DurationAttr : public Attribute {
   Duration GetValue() const { return value_; };
 
  private:
-  Duration value_ = DurationClock::duration::min();
+  Duration value_ = Duration::Min();
 };
 
 // An attribute that keeps the timestamp information as a point in time.

--- a/layer/support/layer_data.cc
+++ b/layer/support/layer_data.cc
@@ -85,10 +85,10 @@ void LayerData::RemoveInstance(VkInstance instance) {
   instance_keys_map_.erase(key);
 }
 
-DurationClock::duration LayerData::GetTimeDelta() {
+Duration LayerData::GetTimeDelta() {
   absl::MutexLock lock(&log_time_lock_);
   DurationClock::time_point now = Now();
-  DurationClock::duration logged_delta = DurationClock::duration::min();
+  Duration logged_delta = Duration::Min();
 
   if (last_log_time_ != DurationClock::time_point::min()) {
     // Using initialized logged_delta

--- a/layer/support/layer_data.h
+++ b/layer/support/layer_data.h
@@ -308,18 +308,18 @@ class LayerData {
 
   // Returns the time difference between the last time this method was called
   // and now. The first call is used for initialization and does not calculate
-  // the time delta. It returns DurationClock::duration::min() indicating an
+  // the time delta. It returns Duration::Min() indicating an
   // invalid time delta. Use case example:
   // ```c++
-  // DurationClock::duration time_delta = GetTimeDelta();
-  // if (time_delta != DurationClock::duration::min()) {
+  // Duration time_delta = GetTimeDelta();
+  // if (time_delta != Duration::Min()) {
   //    std::cout << "Success: time_delta is " << ToInt64Nanoseconds(time_delta)
   //    << std::endl;
   // } else {
   //    std::cerr << "Error: time_delta is invalid." << std::endl;
   // }
   // ```
-  DurationClock::duration GetTimeDelta();
+  Duration GetTimeDelta();
 
   // Returns a string representation of |hash|.
   static std::string ShaderHashToString(uint64_t hash);

--- a/layer/support/layer_utils.h
+++ b/layer/support/layer_utils.h
@@ -91,11 +91,29 @@ DurationClock::time_point Now();
 // represents duration in nanoseconds.
 class Duration {
  public:
+  static Duration Min() { return DurationClock::duration::min(); }
+
   static Duration FromNanoseconds(int64_t nanos) {
     return Duration(DurationClock::duration(nanos));
   }
 
   Duration(DurationClock::duration duration) : duration_{duration} {}
+
+  Duration operator-(const Duration& duration) const {
+    return duration_ - duration.duration_;
+  }
+
+  Duration operator-(const DurationClock::duration& dur) const {
+    return duration_ - dur;
+  }
+
+  bool operator!=(const Duration& dur) const {
+    return duration_ != dur.duration_;
+  }
+
+  bool operator!=(const DurationClock::duration& dur) const {
+    return duration_ != dur;
+  }
 
   int64_t ToNanoseconds() const {
     return std::chrono::nanoseconds(duration_).count();


### PR DESCRIPTION
Although `Duration` is a wrapper around `DurationCLock::duration`, both co-existed in the code. This PR adds overloads to the `Duration` so that it can replace `DurationCLock::duration`.