### PR TITLE
Fix `Timestamp` subtraction problem.

### DIFF
--- a/layer/support/layer_utils.h
+++ b/layer/support/layer_utils.h
@@ -154,7 +154,7 @@ class Timestamp {
   }
 
   Timestamp operator-(const Duration& duration) {
-    return timestamp_ - DurationClock::duration(duration.ToNanoseconds());
+    return timestamp_ - TimestampClock::duration(duration.ToNanoseconds());
   }
 
  private:


### PR DESCRIPTION
The subtraction could not be done because `TimestampClock` and the `DurationClock` were using different precision.