### PR TITLE
Ignore trace events in CSV logger

### DIFF
--- a/docker/test_performance_layers.sh
+++ b/docker/test_performance_layers.sh
@@ -63,17 +63,17 @@ for file in "${output_files[@]}"; do
 done
 
 # Check that log file's contents match what is expected.
-FileCheck "${PROJECT_ROOT_DIR}/test/check_compile_time_log.txt" --input-file \
-  "${OUTPUT_DIR}"/compile_time.csv
+FileCheck "${PROJECT_ROOT_DIR}/test/check_compile_time_log.txt" \
+  --match-full-lines --input-file "${OUTPUT_DIR}"/compile_time.csv
 
-FileCheck "${PROJECT_ROOT_DIR}/test/check_run_time_log.txt" --input-file \
-  "${OUTPUT_DIR}"/run_time.csv
+FileCheck "${PROJECT_ROOT_DIR}/test/check_run_time_log.txt" \
+  --match-full-lines --input-file "${OUTPUT_DIR}"/run_time.csv
 
-FileCheck "${PROJECT_ROOT_DIR}/test/check_memory_usage_log.txt" --input-file \
-  "${OUTPUT_DIR}"/memory_usage.csv
+FileCheck "${PROJECT_ROOT_DIR}/test/check_memory_usage_log.txt" \
+  --match-full-lines --input-file "${OUTPUT_DIR}"/memory_usage.csv
 
-FileCheck "${PROJECT_ROOT_DIR}/test/check_frame_time_log.txt" --input-file \
-  "${OUTPUT_DIR}"/frame_time.csv
+FileCheck "${PROJECT_ROOT_DIR}/test/check_frame_time_log.txt" \
+  --match-full-lines --input-file "${OUTPUT_DIR}"/frame_time.csv
 
-FileCheck "${PROJECT_ROOT_DIR}/test/check_event_log.txt" --input-file \
-  "${OUTPUT_DIR}"/events.log
+FileCheck "${PROJECT_ROOT_DIR}/test/check_event_log.txt" \
+  --match-full-lines --input-file "${OUTPUT_DIR}"/events.log

--- a/layer/memory_usage/memory_usage_layer.cc
+++ b/layer/memory_usage/memory_usage_layer.cc
@@ -39,7 +39,7 @@ class MemoryUsageEvent : public Event {
       : Event(name, LogLevel::kHigh),
         current_({"current", current}),
         peak_({"peak", peak}),
-        trace_attr_("trace_attr_", "memory_usage", "i",
+        trace_attr_("trace_attr", "memory_usage", "i",
                     {&scope_, &current_, &peak_}) {
     InitAttributes({&current_, &peak_, &trace_attr_});
   }

--- a/test/check_event_log.txt
+++ b/test/check_event_log.txt
@@ -4,17 +4,17 @@
 ; consistent.
 ; Counts the number of memory and frame time logs and check if they are
 ; as expected.
-; CHECK-DAG:  compile_time_layer_init,timestamp:{{[0-9]+}}
-; CHECK-DAG:  runtime_layer_init,timestamp:{{[0-9]+}}
-; CHECK-DAG:  memory_usage_layer_init,timestamp:{{[0-9]+}}
-; CHECK-DAG:  frame_time_layer_init,timestamp:{{[0-9]+}}
-; CHECK:      create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}}
-; CHECK-NEXT: create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER2:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}}
-; CHECK:      shader_module_first_use_slack_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1]],slack:{{[0-9]+}}
-; CHECK-NEXT: shader_module_first_use_slack_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER2]],slack:{{[0-9]+}}
-; CHECK:      create_graphics_pipelines,timestamp:{{[0-9]+}},hashes:"[[[SHADER1]],[[SHADER2]]]",duration:{{[0-9]+}}
-; CHECK-DAG:  memory_usage_present,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
-; CHECK-DAG:  frame_present,timestamp:{{[0-9]+}},frame_time:{{[0-9]+}},started:{{[0-9]+}}
-; CHECK-DAG:  pipeline_execution,timestamp:{{[0-9]+}},pipeline:"[[[SHADER1]],[[SHADER2]]]",runtime:{{[0-9]+}},fragment_shader_invocations:{{[0-9]+}},compute_shader_invocations:{{[0-9]+}}
-; CHECK-DAG:  memory_usage_destroy_device,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}}
-; CHECK-DAG:  frame_time_layer_exit,timestamp:{{[0-9]+}},finish_cause:application_exit
+; CHECK-DAG:  compile_time_layer_init,timestamp:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  runtime_layer_init,timestamp:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  memory_usage_layer_init,timestamp:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  frame_time_layer_init,timestamp:{{[0-9]+}},trace_attr:
+; CHECK:      create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}},trace_attr:
+; CHECK-NEXT: create_shader_module_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER2:0x[a-zA-Z0-9]+]],duration:{{[0-9]+}},trace_attr:
+; CHECK:      shader_module_first_use_slack_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER1]],slack:{{[0-9]+}},trace_attr:
+; CHECK-NEXT: shader_module_first_use_slack_ns,timestamp:{{[0-9]+}},shader_hash:[[SHADER2]],slack:{{[0-9]+}},trace_attr:
+; CHECK:      create_graphics_pipelines,timestamp:{{[0-9]+}},hashes:"[[[SHADER1]],[[SHADER2]]]",duration:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  memory_usage_present,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  frame_present,timestamp:{{[0-9]+}},frame_time:{{[0-9]+}},started:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  pipeline_execution,timestamp:{{[0-9]+}},pipeline:"[[[SHADER1]],[[SHADER2]]]",runtime:{{[0-9]+}},fragment_shader_invocations:{{[0-9]+}},compute_shader_invocations:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  memory_usage_destroy_device,timestamp:{{[0-9]+}},current:{{[0-9]+}},peak:{{[0-9]+}},trace_attr:
+; CHECK-DAG:  frame_time_layer_exit,timestamp:{{[0-9]+}},finish_cause:application_exit,trace_attr:


### PR DESCRIPTION
Currently, trace events are ignored by the CSV logger, but the delimiter appending logic does not take that into account, resulting in a delimiter being appended to every line with an empty value after. That causes CSV files not to match the declared header format anymore.

The invalid output looks like this:
```
Frame Time (ns),Benchmark State
16614739,1,
```

This PR makes it so that the CSV logger filters out events that it can't log (only trace events for now). Both unit and FileCheck tests are updated to check for this scenario.

The CommonLogger still outputs such events, but given the fact that it's somewhat more structured (outputs attributes in the format `attribute_name:attribute_value`), I feel it's ok if it outputs an attribute with an empty value as a parser has enough information to skip over it.