### PR TITLE
Fix the slack event bug.

### DIFF
--- a/layer/support/layer_utils.h
+++ b/layer/support/layer_utils.h
@@ -173,6 +173,12 @@ class Timestamp {
     return FromNanoseconds(ToNanoseconds() - duration.ToNanoseconds());
   }
 
+  Duration operator-(const Timestamp& timestamp) {
+    assert(timestamp_ > timestamp.timestamp_);
+    return Duration::FromNanoseconds(
+        detail::DurationToNanoseconds(timestamp_ - timestamp.timestamp_));
+  }
+
  private:
   static TimestampClock::time_point GetCanonicalEpoch() { return {}; }
 

--- a/layer/support/trace_event_logging.cc
+++ b/layer/support/trace_event_logging.cc
@@ -173,7 +173,6 @@ std::string EventToTraceEventString(Event &event) {
               << ", " << std::quoted("pid") << " : "
               << trace_attr->GetPid().GetValue() << ", " << std::quoted("tid")
               << " : " << trace_attr->GetTid().GetValue();
-
   if (phase_str == "X") {
     AppendCompleteEvent(event.GetCreationTime(), trace_attr, json_stream);
   } else if (phase_str == "i") {


### PR DESCRIPTION
A slack event shows the time between creation of a shader and its first use. `ShaderModuleSlack` is used to track these values using `creation_end_time` and `first_use_time` variables. Since the timestamp for an event shows the end of its creation, the `creation_end_time` should be set by the `CreateShaderEvent`'s timestamp. `first_use_time` should be set by the timestamp of the start of the pipeline.

Fix: #150 